### PR TITLE
feat(collaborator): implement create_collaborator — closes #23

### DIFF
--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -1,0 +1,60 @@
+"""
+Collaborator service.
+
+Handles all collaborator management operations — creation, update,
+deactivation, and retrieval. All functions require Management role
+via the @require_role decorator.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from exceptions import DuplicateEmailError
+from models.collaborator import Collaborator
+from models.role import Role
+from permissions.decorators import require_role
+
+
+@require_role("MANAGEMENT")
+def create_collaborator(
+        session:Session,
+        current_user: Collaborator,
+        first_name: str,
+        last_name: str,
+        email: str,
+        role_id: int,
+        password: str
+) -> Collaborator:
+    """
+    Create a new collaborator account.
+
+    Args:
+        session: SQLAlchemy database session.
+        current_user: The authenticated Management collaborator.
+        first_name: New collaborator's first name.
+        last_name: New collaborator's last name.
+        email: New collaborator's email address — must be unique.
+        role_id: FK reference to the Role table.
+        password: Initial plaintext password — will be hashed.
+
+    Returns:
+        Collaborator: The newly created collaborator instance.
+
+    Raises:
+        PermissionDeniedError: If current_user is not Management.
+        DuplicateEmailError: If email already exists.
+    """
+    collaborator = Collaborator()
+    collaborator.first_name = first_name
+    collaborator.last_name = last_name
+    collaborator.email = email
+    collaborator.role_id = role_id
+    collaborator.is_active = True
+    collaborator.must_change_password = True
+    collaborator.set_password(password)
+
+    session.add(collaborator)
+    session.commit()
+
+    return collaborator

--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -45,6 +45,13 @@ def create_collaborator(
         PermissionDeniedError: If current_user is not Management.
         DuplicateEmailError: If email already exists.
     """
+    # Step 1 — check email uniqueness
+    existing = session.query(Collaborator).filter_by(email=email).first()
+    if existing:
+        raise DuplicateEmailError(
+            f"A collaborator with email '{email}' already exists."
+        )
+
     collaborator = Collaborator()
     collaborator.first_name = first_name
     collaborator.last_name = last_name

--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -14,7 +14,8 @@ from exceptions import DuplicateEmailError
 from models.collaborator import Collaborator
 from permissions.decorators import require_role
 
-# ── Collaborator creation helpers ───────────────────────────────────────────────────────
+# ── Collaborator creation helpers ─────────────────────────────────────────────────────
+
 
 def _generate_employee_number(session: Session) -> str:
     """Generate the next sequential employee number.
@@ -31,15 +32,16 @@ def _generate_employee_number(session: Session) -> str:
     count = session.query(Collaborator).count()
     return f"EMP-{count + 1:03d}"
 
+
 @require_role("MANAGEMENT")
 def create_collaborator(
-        session:Session,
-        current_user: Collaborator,  # noqa: ARG001 — consumed by @require_role
-        first_name: str,
-        last_name: str,
-        email: str,
-        role_id: int,
-        password: str,
+    session: Session,
+    current_user: Collaborator,  # noqa: ARG001 — consumed by @require_role
+    first_name: str,
+    last_name: str,
+    email: str,
+    role_id: int,
+    password: str,
 ) -> Collaborator:
     """
     Create a new collaborator account.

--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -12,19 +12,34 @@ from sqlalchemy.orm import Session
 
 from exceptions import DuplicateEmailError
 from models.collaborator import Collaborator
-from models.role import Role
 from permissions.decorators import require_role
 
+# ── Collaborator creation helpers ───────────────────────────────────────────────────────
+
+def _generate_employee_number(session: Session) -> str:
+    """Generate the next sequential employee number.
+
+    Counts all collaborators regardless of active status to ensure
+    numbers are never reused after deactivation.
+
+    Args:
+        session: SQLAlchemy database session.
+
+    Returns:
+        str: Employee number in EMP-XXX format.
+    """
+    count = session.query(Collaborator).count()
+    return f"EMP-{count + 1:03d}"
 
 @require_role("MANAGEMENT")
 def create_collaborator(
         session:Session,
-        current_user: Collaborator,
+        current_user: Collaborator,  # noqa: ARG001 — consumed by @require_role
         first_name: str,
         last_name: str,
         email: str,
         role_id: int,
-        password: str
+        password: str,
 ) -> Collaborator:
     """
     Create a new collaborator account.
@@ -32,6 +47,7 @@ def create_collaborator(
     Args:
         session: SQLAlchemy database session.
         current_user: The authenticated Management collaborator.
+                    Consumed by @require_role — not used in the function body.
         first_name: New collaborator's first name.
         last_name: New collaborator's last name.
         email: New collaborator's email address — must be unique.
@@ -52,7 +68,12 @@ def create_collaborator(
             f"A collaborator with email '{email}' already exists."
         )
 
+    # Step 2 — generate employee number
+    employee_number = _generate_employee_number(session)
+
+    # Step 3 - create the collaborator
     collaborator = Collaborator()
+    collaborator.employee_number = employee_number
     collaborator.first_name = first_name
     collaborator.last_name = last_name
     collaborator.email = email

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,9 @@ Fixtures are organised as:
 
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
+from unittest.mock import MagicMock
 
 import pytest
-from unittest.mock import MagicMock
 
 from models.client import Client
 from models.collaborator import Collaborator
@@ -480,7 +480,9 @@ def mock_authenticated_session(monkeypatch):
     )
     return payload
 
+
 # ── Collaborator service setup ──────────────────────────────────────────────────────
+
 
 @pytest.fixture
 def mock_session_empty():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 
 import pytest
+from unittest.mock import MagicMock
 
 from models.client import Client
 from models.collaborator import Collaborator
@@ -478,3 +479,13 @@ def mock_authenticated_session(monkeypatch):
         lambda token: payload,
     )
     return payload
+
+# ── Collaborator service setup ──────────────────────────────────────────────────────
+
+@pytest.fixture
+def mock_session_empty():
+    """Return a MagicMock session with no existing collaborators."""
+    session = MagicMock()
+    session.query.return_value.filter_by.return_value.first.return_value = None
+    session.query.return_value.count.return_value = 0
+    return session

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -10,7 +10,7 @@ Tests are organised by function:
 import pytest
 from unittest.mock import MagicMock
 
-from exceptions import DuplicateEmailError
+from exceptions import DuplicateEmailError, PermissionDeniedError
 from services.collaborator_service import (
 create_collaborator,
 )
@@ -53,6 +53,21 @@ class TestCreateCollaborator:
                 first_name="Sophie",
                 last_name="Marceau",
                 email="already.exists@epicevents.com",
+                role_id=2,
+                password="initialpassword123",
+            )
+
+    def test_non_management_caller_raises(self, commercial_user):
+        """Non-Management caller raises PermissionDeniedError."""
+        session = MagicMock()
+
+        with pytest.raises(PermissionDeniedError):
+            create_collaborator(
+                session=session,
+                current_user=commercial_user,
+                first_name="Sophie",
+                last_name="Marceau",
+                email="sophie.marceau@epicevents.com",
                 role_id=2,
                 password="initialpassword123",
             )

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -7,13 +7,16 @@ Tests are organised by function:
     - get_collaborators
     - get_collaborator_by_id
 """
-import pytest
+
 from unittest.mock import MagicMock
+
+import pytest
 
 from exceptions import DuplicateEmailError, PermissionDeniedError
 from services.collaborator_service import (
-create_collaborator,
+    create_collaborator,
 )
+
 
 class TestCreateCollaborator:
     """Tests for the create_collaborator service function."""
@@ -23,7 +26,7 @@ class TestCreateCollaborator:
     # ---------------------------
 
     def test_valid_input_creates_collaborator(
-            self, management_user, mock_session_empty
+        self, management_user, mock_session_empty
     ):
         """Valid input creates a collaborator with correct defaults."""
         result = create_collaborator(
@@ -42,9 +45,7 @@ class TestCreateCollaborator:
         mock_session_empty.add.assert_called_once()
         mock_session_empty.commit.assert_called_once()
 
-    def test_employee_number_is_generated(
-            self, management_user, mock_session_empty
-    ):
+    def test_employee_number_is_generated(self, management_user, mock_session_empty):
         """Employoee number is auto-generated in EMP-XXX format."""
         result = create_collaborator(
             session=mock_session_empty,
@@ -65,7 +66,9 @@ class TestCreateCollaborator:
     def test_duplicate_email_raises(self, management_user):
         """Duplicate email raises DuplicateEmailError."""
         session = MagicMock()
-        session.query.return_value.filter_by.return_value.first.return_value = MagicMock()
+        session.query.return_value.filter_by.return_value.first.return_value = (
+            MagicMock()
+        )
 
         with pytest.raises(DuplicateEmailError):
             create_collaborator(

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -7,8 +7,10 @@ Tests are organised by function:
     - get_collaborators
     - get_collaborator_by_id
 """
+import pytest
 from unittest.mock import MagicMock
 
+from exceptions import DuplicateEmailError
 from services.collaborator_service import (
 create_collaborator,
 )
@@ -38,3 +40,19 @@ class TestCreateCollaborator:
         assert result.password_hash != "initialpassword123"
         session.add.assert_called_once()
         session.commit.assert_called_once()
+
+    def test_duplicate_email_raises(self, management_user):
+        """Duplicate email raises DuplicateEmailError."""
+        session = MagicMock()
+        session.query.return_value.filter_by.return_value.first.return_value = MagicMock()
+
+        with pytest.raises(DuplicateEmailError):
+            create_collaborator(
+                session=session,
+                current_user=management_user,
+                first_name="Sophie",
+                last_name="Marceau",
+                email="already.exists@epicevents.com",
+                role_id=2,
+                password="initialpassword123",
+            )

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -18,15 +18,16 @@ create_collaborator,
 class TestCreateCollaborator:
     """Tests for the create_collaborator service function."""
 
+    # ---------------------------
+    # Happy path
+    # ---------------------------
+
     def test_valid_input_creates_collaborator(
-            self, management_user, management_role
+            self, management_user, mock_session_empty
     ):
         """Valid input creates a collaborator with correct defaults."""
-        session = MagicMock()
-        session.query.return_value.filter_by.return_value.first.return_value = None
-
         result = create_collaborator(
-            session=session,
+            session=mock_session_empty,
             current_user=management_user,
             first_name="Sophie",
             last_name="Marceau",
@@ -38,8 +39,28 @@ class TestCreateCollaborator:
         assert result.must_change_password is True
         assert result.is_active is True
         assert result.password_hash != "initialpassword123"
-        session.add.assert_called_once()
-        session.commit.assert_called_once()
+        mock_session_empty.add.assert_called_once()
+        mock_session_empty.commit.assert_called_once()
+
+    def test_employee_number_is_generated(
+            self, management_user, mock_session_empty
+    ):
+        """Employoee number is auto-generated in EMP-XXX format."""
+        result = create_collaborator(
+            session=mock_session_empty,
+            current_user=management_user,
+            first_name="Sophie",
+            last_name="Marceau",
+            email="sophie.marceau@epicevents.com",
+            role_id=2,
+            password="initialpassword123",
+        )
+
+        assert result.employee_number == "EMP-001"
+
+    # ---------------------------
+    # Sad path
+    # ---------------------------
 
     def test_duplicate_email_raises(self, management_user):
         """Duplicate email raises DuplicateEmailError."""

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -1,0 +1,40 @@
+"""Unit tests for the collaborator service.
+
+Tests are organised by function:
+    - create_collaborator
+    - update_collaborator
+    - deactivate_collaborator
+    - get_collaborators
+    - get_collaborator_by_id
+"""
+from unittest.mock import MagicMock
+
+from services.collaborator_service import (
+create_collaborator,
+)
+
+class TestCreateCollaborator:
+    """Tests for the create_collaborator service function."""
+
+    def test_valid_input_creates_collaborator(
+            self, management_user, management_role
+    ):
+        """Valid input creates a collaborator with correct defaults."""
+        session = MagicMock()
+        session.query.return_value.filter_by.return_value.first.return_value = None
+
+        result = create_collaborator(
+            session=session,
+            current_user=management_user,
+            first_name="Sophie",
+            last_name="Marceau",
+            email="sophie.marceau@epicevents.com",
+            role_id=2,
+            password="initialpassword123",
+        )
+
+        assert result.must_change_password is True
+        assert result.is_active is True
+        assert result.password_hash != "initialpassword123"
+        session.add.assert_called_once()
+        session.commit.assert_called_once()


### PR DESCRIPTION
- create_collaborator() with email uniqueness check, employee_number
  generation, bcrypt hashing, must_change_password = True on creation
- _generate_employee_number() private helper
- DuplicateEmailError in exceptions.py
- 4 unit tests covering happy path, duplicate email, permission denied,
  and employee number format
  
  Closes #23 