### PR TITLE
feat(collaborator): implement update_collaborator — closes #24

### DIFF
--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -76,7 +76,7 @@ def create_collaborator(
     # Step 2 — generate employee number
     employee_number = _generate_employee_number(session)
 
-    # Step 3 - create the collaborator
+    # Step 3 - build the collaborator
     collaborator = Collaborator()
     collaborator.employee_number = employee_number
     collaborator.first_name = first_name

--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -16,6 +16,7 @@ from permissions.decorators import require_role
 
 # ── Collaborator creation helpers ─────────────────────────────────────────────────────
 
+
 def _generate_employee_number(session: Session) -> str:
     """Generate the next sequential employee number.
 
@@ -31,7 +32,9 @@ def _generate_employee_number(session: Session) -> str:
     count = session.query(Collaborator).count()
     return f"EMP-{count + 1:03d}"
 
+
 # ── Public Interface ─────────────────────────────────────────────────────────────────
+
 
 @require_role("MANAGEMENT")
 def create_collaborator(
@@ -89,16 +92,17 @@ def create_collaborator(
 
     return collaborator
 
+
 @require_role("MANAGEMENT")
 def update_collaborator(
-        session: Session,
-        current_user: Collaborator,  # noqa: ARG001 — consumed by @require_role
-        collaborator: Collaborator,
-        first_name: str | None = None,
-        last_name: str | None = None,
-        email: str | None = None,
-        phone: str | None = None,
-        role_id: int | None = None,
+    session: Session,
+    current_user: Collaborator,  # noqa: ARG001 — consumed by @require_role
+    collaborator: Collaborator,
+    first_name: str | None = None,
+    last_name: str | None = None,
+    email: str | None = None,
+    phone: str | None = None,
+    role_id: int | None = None,
 ) -> Collaborator:
     """
     Update an existing collaborator account/details.
@@ -123,6 +127,9 @@ def update_collaborator(
     if first_name is not None:
         collaborator.first_name = first_name
 
+    if last_name is not None:
+        collaborator.last_name = last_name
+
     if email is not None:
         existing = session.query(Collaborator).filter_by(email=email).first()
         if existing and existing.id != collaborator.id:
@@ -130,6 +137,12 @@ def update_collaborator(
                 f"A collaborator with email '{email}' already exists."
             )
         collaborator.email = email
+
+    if phone is not None:
+        collaborator.phone = phone
+
+    if role_id is not None:
+        collaborator.role_id = role_id
 
     session.commit()
     return collaborator

--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -16,7 +16,6 @@ from permissions.decorators import require_role
 
 # ── Collaborator creation helpers ─────────────────────────────────────────────────────
 
-
 def _generate_employee_number(session: Session) -> str:
     """Generate the next sequential employee number.
 
@@ -32,6 +31,7 @@ def _generate_employee_number(session: Session) -> str:
     count = session.query(Collaborator).count()
     return f"EMP-{count + 1:03d}"
 
+# ── Public Interface ─────────────────────────────────────────────────────────────────
 
 @require_role("MANAGEMENT")
 def create_collaborator(
@@ -87,4 +87,49 @@ def create_collaborator(
     session.add(collaborator)
     session.commit()
 
+    return collaborator
+
+@require_role("MANAGEMENT")
+def update_collaborator(
+        session: Session,
+        current_user: Collaborator,  # noqa: ARG001 — consumed by @require_role
+        collaborator: Collaborator,
+        first_name: str | None = None,
+        last_name: str | None = None,
+        email: str | None = None,
+        phone: str | None = None,
+        role_id: int | None = None,
+) -> Collaborator:
+    """
+    Update an existing collaborator account/details.
+
+    Args:
+        session: SQLAlchemy database session.
+        current_user: The authenticated Management collaborator.
+        collaborator: The Collaborator instance to update.
+        first_name: New first name, or None to leave unchanged.
+        last_name: New last name, or None to leave unchanged.
+        email: New email address, or None to leave unchanged.
+        phone: New phone number, or None to leave unchanged.
+        role_id: New role FK, or None to leave unchanged.
+
+    Returns:
+        Collaborator: The updated collaborator instance.
+
+    Raises:
+        PermissionDeniedError: If current_user is not Management.
+        DuplicateEmailError: If new email already belongs to another collaborator.
+    """
+    if first_name is not None:
+        collaborator.first_name = first_name
+
+    if email is not None:
+        existing = session.query(Collaborator).filter_by(email=email).first()
+        if existing and existing.id != collaborator.id:
+            raise DuplicateEmailError(
+                f"A collaborator with email '{email}' already exists."
+            )
+        collaborator.email = email
+
+    session.commit()
     return collaborator

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -128,3 +128,32 @@ class TestUpdateCollaborator:
 
         assert result.first_name == "Robert"
         session.commit.assert_called_once()
+
+    # ---------------------------
+    # Sad path
+    # ---------------------------
+
+    def test_duplicate_email_on_update_raises(
+            self, management_user, make_collaborator, management_role
+    ):
+        """Updating to an existing email raises DuplicateEmailError."""
+        target = make_collaborator(
+            id=2,
+            email="bob.dupont@epicevents.com",
+            role=management_role,
+        )
+        existing = make_collaborator(
+            id=3,
+            email="already.taken@epicevents.com",
+            role=management_role,
+        )
+        session = MagicMock()
+        session.query.return_value.filter_by.return_value.first.return_value = existing
+
+        with pytest.raises(DuplicateEmailError):
+            update_collaborator(
+                session=session,
+                current_user=management_user,
+                collaborator=target,
+                email="already.taken@epicevents.com",
+            )

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -157,3 +157,22 @@ class TestUpdateCollaborator:
                 collaborator=target,
                 email="already.taken@epicevents.com",
             )
+
+    def test_non_management_caller_raises(
+            self, commercial_user, make_collaborator, management_role
+    ):
+        """Non-Management caller raises PermissionDeniedError."""
+        target = make_collaborator(
+            id=2,
+            email="bob.dupont@epicevents.com",
+            role=management_role,
+        )
+        session = MagicMock()
+
+        with pytest.raises(PermissionDeniedError):
+            update_collaborator(
+                session=session,
+                current_user=commercial_user,
+                collaborator=target,
+                first_name="Robert",
+            )

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -15,6 +15,7 @@ import pytest
 from exceptions import DuplicateEmailError, PermissionDeniedError
 from services.collaborator_service import (
     create_collaborator,
+    update_collaborator
 )
 
 
@@ -95,3 +96,35 @@ class TestCreateCollaborator:
                 role_id=2,
                 password="initialpassword123",
             )
+
+class TestUpdateCollaborator:
+    """Tests for the update_collaborator service function."""
+
+    # ---------------------------
+    # Happy path
+    # ---------------------------
+
+    def test_valid_update_persists_fields(
+            self, management_user, make_collaborator, management_role
+    ):
+        """Valid update persists changed fields and commits."""
+        target = make_collaborator(
+            id=2,
+            first_name="Bob",
+            last_name="Dupont",
+            email="bob.dupont@epicevents.com",
+            role=management_role,
+        )
+
+        session = MagicMock()
+        session.query.return_value.filter_by.return_value.first.return_value = None
+
+        result = update_collaborator(
+            session=session,
+            current_user=management_user,
+            collaborator=target,
+            first_name="Robert",
+        )
+
+        assert result.first_name == "Robert"
+        session.commit.assert_called_once()

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -102,9 +102,7 @@ class TestUpdateCollaborator:
     # Happy path
     # ---------------------------
 
-    def test_valid_update_persists_fields(
-        self, management_user, make_collaborator
-    ):
+    def test_valid_update_persists_fields(self, management_user, make_collaborator):
         """Valid update persists changed fields and commits."""
         target = make_collaborator(
             id=2,
@@ -181,7 +179,9 @@ class TestUpdateCollaborator:
             )
 
     def test_non_management_caller_raises(
-        self, commercial_user, make_collaborator,
+        self,
+        commercial_user,
+        make_collaborator,
     ):
         """Non-Management caller raises PermissionDeniedError."""
         target = make_collaborator(

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -13,10 +13,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from exceptions import DuplicateEmailError, PermissionDeniedError
-from services.collaborator_service import (
-    create_collaborator,
-    update_collaborator
-)
+from services.collaborator_service import create_collaborator, update_collaborator
 
 
 class TestCreateCollaborator:
@@ -97,6 +94,7 @@ class TestCreateCollaborator:
                 password="initialpassword123",
             )
 
+
 class TestUpdateCollaborator:
     """Tests for the update_collaborator service function."""
 
@@ -105,7 +103,7 @@ class TestUpdateCollaborator:
     # ---------------------------
 
     def test_valid_update_persists_fields(
-            self, management_user, make_collaborator, management_role
+        self, management_user, make_collaborator, management_role
     ):
         """Valid update persists changed fields and commits."""
         target = make_collaborator(
@@ -129,12 +127,37 @@ class TestUpdateCollaborator:
         assert result.first_name == "Robert"
         session.commit.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "field, value",
+        [
+            ("last_name", "Martin"),
+            ("phone", "0612345678"),
+            ("role_id", 3),
+        ],
+    )
+    def test_partial_update_applies_field(
+        self, management_user, make_collaborator, management_role, field, value
+    ):
+        """Each updatable field is applied when provided."""
+        target = make_collaborator(id=2, role=management_role)
+        session = MagicMock()
+        session.query.return_value.filter_by.return_value.first.return_value = None
+
+        update_collaborator(
+            session=session,
+            current_user=management_user,
+            collaborator=target,
+            **{field: value},
+        )
+
+        assert getattr(target, field) == value
+
     # ---------------------------
     # Sad path
     # ---------------------------
 
     def test_duplicate_email_on_update_raises(
-            self, management_user, make_collaborator, management_role
+        self, management_user, make_collaborator, management_role
     ):
         """Updating to an existing email raises DuplicateEmailError."""
         target = make_collaborator(
@@ -159,7 +182,7 @@ class TestUpdateCollaborator:
             )
 
     def test_non_management_caller_raises(
-            self, commercial_user, make_collaborator, management_role
+        self, commercial_user, make_collaborator, management_role
     ):
         """Non-Management caller raises PermissionDeniedError."""
         target = make_collaborator(

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -44,7 +44,7 @@ class TestCreateCollaborator:
         mock_session_empty.commit.assert_called_once()
 
     def test_employee_number_is_generated(self, management_user, mock_session_empty):
-        """Employoee number is auto-generated in EMP-XXX format."""
+        """Employee number is auto-generated in EMP-XXX format."""
         result = create_collaborator(
             session=mock_session_empty,
             current_user=management_user,
@@ -103,7 +103,7 @@ class TestUpdateCollaborator:
     # ---------------------------
 
     def test_valid_update_persists_fields(
-        self, management_user, make_collaborator, management_role
+        self, management_user, make_collaborator
     ):
         """Valid update persists changed fields and commits."""
         target = make_collaborator(
@@ -111,7 +111,6 @@ class TestUpdateCollaborator:
             first_name="Bob",
             last_name="Dupont",
             email="bob.dupont@epicevents.com",
-            role=management_role,
         )
 
         session = MagicMock()
@@ -136,10 +135,10 @@ class TestUpdateCollaborator:
         ],
     )
     def test_partial_update_applies_field(
-        self, management_user, make_collaborator, management_role, field, value
+        self, management_user, make_collaborator, field, value
     ):
         """Each updatable field is applied when provided."""
-        target = make_collaborator(id=2, role=management_role)
+        target = make_collaborator(id=2)
         session = MagicMock()
         session.query.return_value.filter_by.return_value.first.return_value = None
 
@@ -182,13 +181,12 @@ class TestUpdateCollaborator:
             )
 
     def test_non_management_caller_raises(
-        self, commercial_user, make_collaborator, management_role
+        self, commercial_user, make_collaborator,
     ):
         """Non-Management caller raises PermissionDeniedError."""
         target = make_collaborator(
             id=2,
             email="bob.dupont@epicevents.com",
-            role=management_role,
         )
         session = MagicMock()
 


### PR DESCRIPTION
## Summary

Implements `update_collaborator()` in `services/collaborator_service.py`,
completing US-02.

Closes #24 (US-02 — Update collaborator details)

---

## What was delivered

- `update_collaborator()` — accepts partial updates for first_name,
  last_name, email, phone, role_id. Only provided fields are updated.
- Email uniqueness enforced on update — DuplicateEmailError raised if
  new email already belongs to another collaborator
- Role change takes effect on next login — JWT carries old role until
  re-authentication
- updated_at handled automatically by SQLAlchemy onupdate on the model

---

## Tests

- Valid update → fields persisted, session committed
- Duplicate email on update → DuplicateEmailError
- Non-Management caller → PermissionDeniedError
- Parametrized: last_name, phone, role_id each applied correctly

Closes #24 