### PR TITLE
Feature/sprint2 auth -- Deactivate Collaborator with Active Dossier Check [Closes #25]

### DIFF
--- a/exceptions.py
+++ b/exceptions.py
@@ -210,15 +210,23 @@ class PaymentExceedsBalanceError(PaymentError):
 # ── Collaborator deactivation ──────────────────────────────────────────────────
 
 
-class ReassignmentRequiredError(EpicEventsError):
-    """Raised when deactivation is attempted with active dossiers still assigned.
-
-    Deactivation is blocked until all clients, open contracts, and
-    non-cancelled events belonging to the collaborator are reassigned
-    to another collaborator.
+class ReassignmentRequiredError(Exception):
+    """
+    Raised when a collaborator has active dossiers that must be reassigned
+    before deactivation.
     """
 
-    pass
+    def __init__(self, message: str = None, dossiers: dict | None = None):
+        """
+        Args:
+            message: Optional human-readable message
+            dossiers: Optional dict of active dossiers, e.g.:
+                      {"clients": [...], "contracts": [...], "events": [...]}
+        """
+        if message is None:
+            message = "Collaborator has active dossiers that must be reassigned."
+        super().__init__(message)
+        self.dossiers = dossiers or {}
 
 
 # ── Event assignment ───────────────────────────────────────────────────────────

--- a/exceptions.py
+++ b/exceptions.py
@@ -212,12 +212,16 @@ class PaymentExceedsBalanceError(PaymentError):
 
 class ReassignmentRequiredError(Exception):
     """
+    Used by Managers when Deactivating Collaborators.
+
     Raised when a collaborator has active dossiers that must be reassigned
     before deactivation.
     """
 
     def __init__(self, message: str = None, dossiers: dict | None = None):
         """
+        Define the exception message.
+
         Args:
             message: Optional human-readable message
             dossiers: Optional dict of active dossiers, e.g.:

--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -11,12 +11,12 @@ from __future__ import annotations
 from sqlalchemy.orm import Session
 
 from exceptions import DuplicateEmailError, ReassignmentRequiredError
-from models.collaborator import Collaborator
 from models.client import Client
+from models.collaborator import Collaborator
 from models.contract import Contract, ContractStatus
 from models.event import Event
-from services.auth_service import settings
 from permissions.decorators import require_role
+from services.auth_service import settings
 
 # ── Collaborator helpers ─────────────────────────────────────────────────────
 
@@ -36,6 +36,7 @@ def _generate_employee_number(session: Session) -> str:
     count = session.query(Collaborator).count()
     return f"EMP-{count + 1:03d}"
 
+
 def _has_active_dossiers(dossiers: dict) -> bool:
     """
     Check if any active dossiers exist.
@@ -54,6 +55,7 @@ def _has_active_dossiers(dossiers: dict) -> bool:
         ]
     )
 
+
 def _delete_session_file() -> None:
     """
     Delete the current session file if it exists.
@@ -68,6 +70,7 @@ def _delete_session_file() -> None:
     except OSError:
         # Defensive: avoid breaking deactivation on filesystem issues
         pass
+
 
 def get_active_dossiers(session: Session, collaborator: Collaborator) -> dict:
     """
@@ -84,12 +87,9 @@ def get_active_dossiers(session: Session, collaborator: Collaborator) -> dict:
             "events": list[Event],
         }
     """
-
     # ── Clients ────────────────────────────────────────────────
     clients = (
-        session.query(Client)
-        .filter(Client.commercial_id == collaborator.id)
-        .all()
+        session.query(Client).filter(Client.commercial_id == collaborator.id).all()
     )
 
     # ── Contracts (exclude CANCELLED + PAID_IN_FULL) ───────────
@@ -120,6 +120,7 @@ def get_active_dossiers(session: Session, collaborator: Collaborator) -> dict:
         "contracts": contracts,
         "events": events,
     }
+
 
 # ── Public Interface ─────────────────────────────────────────────────────────────────
 
@@ -235,6 +236,7 @@ def update_collaborator(
     session.commit()
     return collaborator
 
+
 @require_role("MANAGEMENT")
 def deactivate_collaborator(
     session: Session,
@@ -247,7 +249,6 @@ def deactivate_collaborator(
     Raises:
         ReassignmentRequiredError: If active dossiers exist.
     """
-
     # Step 1 — retrieve active dossiers
     dossiers = get_active_dossiers(
         session=session,

--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -206,8 +206,9 @@ def deactivate_collaborator(
         session: Session,
         current_user: Collaborator,   # noqa: ARG001 — consumed by @require_role
         collaborator: Collaborator,
-):
+) -> None:
     """
     Allows a Manager to deactivate an existing collaborator.
     """
-    pass
+    collaborator.is_active = False
+    session.commit()

--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -36,6 +36,39 @@ def _generate_employee_number(session: Session) -> str:
     count = session.query(Collaborator).count()
     return f"EMP-{count + 1:03d}"
 
+def _has_active_dossiers(dossiers: dict) -> bool:
+    """
+    Check if any active dossiers exist.
+
+    Args:
+        dossiers: Dict of dossier lists.
+
+    Returns:
+        bool: True if any dossier list is non-empty.
+    """
+    return any(
+        [
+            dossiers["clients"],
+            dossiers["contracts"],
+            dossiers["events"],
+        ]
+    )
+
+def _delete_session_file() -> None:
+    """
+    Delete the current session file if it exists.
+
+    Safe to call even if file is missing.
+    """
+    session_file = settings.session_file
+
+    try:
+        if session_file.exists():
+            session_file.unlink()
+    except OSError:
+        # Defensive: avoid breaking deactivation on filesystem issues
+        pass
+
 def get_active_dossiers(session: Session, collaborator: Collaborator) -> dict:
     """
     Retrieve all active dossiers linked to a collaborator.
@@ -204,29 +237,33 @@ def update_collaborator(
 
 @require_role("MANAGEMENT")
 def deactivate_collaborator(
-        session: Session,
-        current_user: Collaborator,   # noqa: ARG001 — consumed by @require_role
-        collaborator: Collaborator,
+    session: Session,
+    current_user: Collaborator,  # noqa: ARG001
+    collaborator: Collaborator,
 ) -> None:
     """
-    Allows a Manager to deactivate an existing collaborator.
+    Deactivate a collaborator after ensuring no active dossiers remain.
+
+    Raises:
+        ReassignmentRequiredError: If active dossiers exist.
     """
 
-    # Step 1 — check for active dossiers
-    dossiers = get_active_dossiers(session=session, collaborator=collaborator)
+    # Step 1 — retrieve active dossiers
+    dossiers = get_active_dossiers(
+        session=session,
+        collaborator=collaborator,
+    )
 
-    if any(dossiers.values()):
-        raise ReassignmentRequiredError(
-            "Collaborator has active dossiers that must be reassigned."
-        )
+    # Step 2 - enforce reassignment rule
+    if _has_active_dossiers(dossiers):
+        # Pass the full dossiers dict for detailed error handling
+        raise ReassignmentRequiredError(dossiers=dossiers)
 
-    # Step 2 — deactivate
+    # Step 3 — deactivate collaborator
     collaborator.is_active = False
 
-    # Step 3 - delete session file if it exists
-    session_file = settings.session_file
-    if session_file.exists():
-        session_file.unlink()
+    # Step 4 - cleanup session
+    _delete_session_file()
 
-    # Step 4 — commit changes
+    # Step 5 — persist changes
     session.commit()

--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -10,11 +10,14 @@ from __future__ import annotations
 
 from sqlalchemy.orm import Session
 
-from exceptions import DuplicateEmailError
+from exceptions import DuplicateEmailError, ReassignmentRequiredError
 from models.collaborator import Collaborator
+from models.client import Client
+from models.contract import Contract, ContractStatus
+from models.event import Event
 from permissions.decorators import require_role
 
-# ── Collaborator creation helpers ─────────────────────────────────────────────────────
+# ── Collaborator helpers ─────────────────────────────────────────────────────
 
 
 def _generate_employee_number(session: Session) -> str:
@@ -32,6 +35,57 @@ def _generate_employee_number(session: Session) -> str:
     count = session.query(Collaborator).count()
     return f"EMP-{count + 1:03d}"
 
+def get_active_dossiers(session: Session, collaborator: Collaborator) -> dict:
+    """
+    Retrieve all active dossiers linked to a collaborator.
+
+    Args:
+        session: SQLAlchemy database session.
+        collaborator: The collaborator to inspect.
+
+    Returns:
+        dict: {
+            "clients": list[Client],
+            "contracts": list[Contract],
+            "events": list[Event],
+        }
+    """
+
+    # ── Clients ────────────────────────────────────────────────
+    clients = (
+        session.query(Client)
+        .filter(Client.commercial_id == collaborator.id)
+        .all()
+    )
+
+    # ── Contracts (exclude CANCELLED + PAID_IN_FULL) ───────────
+    contracts = (
+        session.query(Contract)
+        .filter(
+            Contract.commercial_id == collaborator.id,
+            Contract.status.notin_(
+                [ContractStatus.CANCELLED, ContractStatus.PAID_IN_FULL]
+            ),
+        )
+        .all()
+    )
+
+    # ── Events (only active, not cancelled) ────────────────────
+    events = (
+        session.query(Event)
+        .filter(
+            Event.support_id == collaborator.id,
+            Event.is_cancelled.is_(False),
+        )
+        .all()
+    )
+
+    # ── Return structured result ───────────────────────────────
+    return {
+        "clients": clients,
+        "contracts": contracts,
+        "events": events,
+    }
 
 # ── Public Interface ─────────────────────────────────────────────────────────────────
 
@@ -146,3 +200,14 @@ def update_collaborator(
 
     session.commit()
     return collaborator
+
+@require_role("MANAGEMENT")
+def deactivate_collaborator(
+        session: Session,
+        current_user: Collaborator,   # noqa: ARG001 — consumed by @require_role
+        collaborator: Collaborator,
+):
+    """
+    Allows a Manager to deactivate an existing collaborator.
+    """
+    pass

--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -210,5 +210,15 @@ def deactivate_collaborator(
     """
     Allows a Manager to deactivate an existing collaborator.
     """
+
+    # Step 1 — check for active dossiers
+    dossiers = get_active_dossiers(session=session, collaborator=collaborator)
+
+    if any(dossiers.values()):
+        raise ReassignmentRequiredError(
+            "Collaborator has active dossiers that must be reassigned."
+        )
+
+    # Step 2 — deactivate
     collaborator.is_active = False
     session.commit()

--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -15,6 +15,7 @@ from models.collaborator import Collaborator
 from models.client import Client
 from models.contract import Contract, ContractStatus
 from models.event import Event
+from services.auth_service import settings
 from permissions.decorators import require_role
 
 # ── Collaborator helpers ─────────────────────────────────────────────────────
@@ -221,4 +222,11 @@ def deactivate_collaborator(
 
     # Step 2 — deactivate
     collaborator.is_active = False
+
+    # Step 3 - delete session file if it exists
+    session_file = settings.session_file
+    if session_file.exists():
+        session_file.unlink()
+
+    # Step 4 — commit changes
     session.commit()

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -18,7 +18,7 @@ from services.collaborator_service import (
     update_collaborator,
     get_active_dossiers
 )
-
+from models.contract import ContractStatus
 
 class TestCreateCollaborator:
     """Tests for the create_collaborator service function."""
@@ -206,6 +206,10 @@ class TestUpdateCollaborator:
 class TestGetActiveDossiers:
     """Tests for helper that retrieves active dossiers for a collaborator."""
 
+    # ---------------------------
+    # Happy path
+    # ---------------------------
+
     def test_returns_all_active_dossiers(
         self,
         make_collaborator,
@@ -242,3 +246,105 @@ class TestGetActiveDossiers:
         assert result["clients"] == clients
         assert result["contracts"] == contracts
         assert result["events"] == events
+
+    def test_all_clients_are_returned(
+            self,
+            make_collaborator,
+            make_client,
+    ):
+        """All clients linked to collaborator are returned."""
+
+        collaborator = make_collaborator(id=42)
+
+        clients = [
+            make_client(id=1, commercial_id=42),
+            make_client(id=2, commercial_id=42),
+        ]
+
+        session = MagicMock()
+        session.query.return_value.filter.return_value.all.side_effect = [
+            clients,
+            [],
+            [],
+        ]
+
+        result = get_active_dossiers(session=session, collaborator=collaborator)
+
+        assert result["clients"] == clients
+
+    # ---------------------------
+    # Sad path
+    # ---------------------------
+
+    def test_returns_empty_lists_when_no_dossiers(
+            self,
+            make_collaborator,
+    ):
+        """Returns empty lists when collaborator has no linked dossiers."""
+
+        collaborator = make_collaborator(id=42)
+
+        session = MagicMock()
+        session.query.return_value.filter.return_value.all.side_effect = [
+            [],  # clients
+            [],  # contracts
+            [],  # events
+        ]
+
+        result = get_active_dossiers(session=session, collaborator=collaborator)
+
+        assert result == {
+            "clients": [],
+            "contracts": [],
+            "events": [],
+        }
+
+    def test_excludes_cancelled_and_paid_contracts(
+            self,
+            make_collaborator,
+            make_contract,
+    ):
+        """Contracts with CANCELLED or PAID_IN_FULL status are excluded."""
+
+        collaborator = make_collaborator(id=42)
+
+        active_contract = make_contract(id=1, commercial_id=42)
+        cancelled_contract = make_contract(id=2, commercial_id=42)
+        cancelled_contract.status = ContractStatus.CANCELLED
+
+        paid_contract = make_contract(id=3, commercial_id=42)
+        paid_contract.status = ContractStatus.PAID_IN_FULL
+
+        session = MagicMock()
+        session.query.return_value.filter.return_value.all.side_effect = [
+            [],  # clients
+            [active_contract],  # contracts → DB already filtered
+            [],  # events
+        ]
+
+        result = get_active_dossiers(session=session, collaborator=collaborator)
+
+        assert active_contract in result["contracts"]
+
+    def test_excludes_cancelled_events(
+            self,
+            make_collaborator,
+            make_event,
+    ):
+        """Cancelled events are excluded from active dossiers."""
+
+        collaborator = make_collaborator(id=42)
+
+        active_event = make_event(id=1, support_id=42, is_cancelled=False)
+        cancelled_event = make_event(id=2, support_id=42, is_cancelled=True)
+
+        session = MagicMock()
+        session.query.return_value.filter.return_value.all.side_effect = [
+            [],  # clients
+            [],  # contracts
+            [active_event],  # events → DB already filtered
+        ]
+
+        result = get_active_dossiers(session=session, collaborator=collaborator)
+
+        assert active_event in result["events"]

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -8,20 +8,23 @@ Tests are organised by function:
     - get_collaborator_by_id
 """
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
-from unittest.mock import patch
 
-from exceptions import DuplicateEmailError, PermissionDeniedError, ReassignmentRequiredError
-from services.auth_service import settings
-from services.collaborator_service import (
-    create_collaborator,
-    update_collaborator,
-    get_active_dossiers,
-    deactivate_collaborator,
+from exceptions import (
+    DuplicateEmailError,
+    PermissionDeniedError,
+    ReassignmentRequiredError,
 )
 from models.contract import ContractStatus
+from services.collaborator_service import (
+    create_collaborator,
+    deactivate_collaborator,
+    get_active_dossiers,
+    update_collaborator,
+)
+
 
 class TestCreateCollaborator:
     """Tests for the create_collaborator service function."""
@@ -221,7 +224,6 @@ class TestGetActiveDossiers:
         make_event,
     ):
         """Returns clients, contracts, and events linked to collaborator."""
-
         # ── Arrange ────────────────────────────────────────────────
         collaborator = make_collaborator(id=42)
 
@@ -237,9 +239,9 @@ class TestGetActiveDossiers:
 
         # Mock query chains in order of calls
         session.query.return_value.filter.return_value.all.side_effect = [
-            clients,    # first call → clients
+            clients,  # first call → clients
             contracts,  # second call → contracts
-            events,     # third call → events
+            events,  # third call → events
         ]
 
         # ── Act ────────────────────────────────────────────────────
@@ -251,12 +253,11 @@ class TestGetActiveDossiers:
         assert result["events"] == events
 
     def test_all_clients_are_returned(
-            self,
-            make_collaborator,
-            make_client,
+        self,
+        make_collaborator,
+        make_client,
     ):
         """All clients linked to collaborator are returned."""
-
         collaborator = make_collaborator(id=42)
 
         clients = [
@@ -280,11 +281,10 @@ class TestGetActiveDossiers:
     # ---------------------------
 
     def test_returns_empty_lists_when_no_dossiers(
-            self,
-            make_collaborator,
+        self,
+        make_collaborator,
     ):
         """Returns empty lists when collaborator has no linked dossiers."""
-
         collaborator = make_collaborator(id=42)
 
         session = MagicMock()
@@ -303,12 +303,11 @@ class TestGetActiveDossiers:
         }
 
     def test_excludes_cancelled_and_paid_contracts(
-            self,
-            make_collaborator,
-            make_contract,
+        self,
+        make_collaborator,
+        make_contract,
     ):
         """Contracts with CANCELLED or PAID_IN_FULL status are excluded."""
-
         collaborator = make_collaborator(id=42)
 
         active_contract = make_contract(id=1, commercial_id=42)
@@ -330,16 +329,14 @@ class TestGetActiveDossiers:
         assert active_contract in result["contracts"]
 
     def test_excludes_cancelled_events(
-            self,
-            make_collaborator,
-            make_event,
+        self,
+        make_collaborator,
+        make_event,
     ):
         """Cancelled events are excluded from active dossiers."""
-
         collaborator = make_collaborator(id=42)
 
         active_event = make_event(id=1, support_id=42, is_cancelled=False)
-        cancelled_event = make_event(id=2, support_id=42, is_cancelled=True)
 
         session = MagicMock()
         session.query.return_value.filter.return_value.all.side_effect = [
@@ -352,6 +349,7 @@ class TestGetActiveDossiers:
 
         assert active_event in result["events"]
 
+
 class TestDeactivateCollaborator:
     """Tests for the deactivate_collaborator service function."""
 
@@ -360,19 +358,18 @@ class TestDeactivateCollaborator:
     # ---------------------------
 
     def test_deactivates_collaborator_when_no_dossiers(
-            self,
-            management_user,
-            make_collaborator,
+        self,
+        management_user,
+        make_collaborator,
     ):
         """Collaborator is deactivated when no active dossiers exist."""
-
         collaborator = make_collaborator(id=42, is_active=True)
 
         session = MagicMock()
 
         with patch(
-                "services.collaborator_service.get_active_dossiers",
-                return_value={"clients": [], "contracts": [], "events": []},
+            "services.collaborator_service.get_active_dossiers",
+            return_value={"clients": [], "contracts": [], "events": []},
         ):
             deactivate_collaborator(
                 session=session,
@@ -384,13 +381,12 @@ class TestDeactivateCollaborator:
         session.commit.assert_called_once()
 
     def test_session_file_deleted_on_deactivation(
-            self,
-            management_user,
-            make_collaborator,
-            session_file,
+        self,
+        management_user,
+        make_collaborator,
+        session_file,
     ):
         """Session file is deleted if it exists."""
-
         collaborator = make_collaborator(id=42)
 
         # Create the file
@@ -399,8 +395,8 @@ class TestDeactivateCollaborator:
         session = MagicMock()
 
         with patch(
-                "services.collaborator_service.get_active_dossiers",
-                return_value={"clients": [], "contracts": [], "events": []},
+            "services.collaborator_service.get_active_dossiers",
+            return_value={"clients": [], "contracts": [], "events": []},
         ):
             deactivate_collaborator(
                 session=session,
@@ -423,19 +419,18 @@ class TestDeactivateCollaborator:
         ],
     )
     def test_raises_if_any_active_dossier_exists(
-            self,
-            management_user,
-            make_collaborator,
-            dossiers,
+        self,
+        management_user,
+        make_collaborator,
+        dossiers,
     ):
         """Raises ReassignmentRequiredError if any type of dossier exists."""
-
         collaborator = make_collaborator(id=42)
         session = MagicMock()
 
         with patch(
-                "services.collaborator_service.get_active_dossiers",
-                return_value=dossiers,
+            "services.collaborator_service.get_active_dossiers",
+            return_value=dossiers,
         ):
             with pytest.raises(ReassignmentRequiredError):
                 deactivate_collaborator(
@@ -447,13 +442,12 @@ class TestDeactivateCollaborator:
         session.commit.assert_not_called()
 
     def test_no_error_if_session_file_missing(
-            self,
-            management_user,
-            make_collaborator,
-            session_file,
+        self,
+        management_user,
+        make_collaborator,
+        session_file,
     ):
         """No error occurs if session file does not exist."""
-
         collaborator = make_collaborator(id=42)
 
         session = MagicMock()
@@ -463,8 +457,8 @@ class TestDeactivateCollaborator:
             session_file.unlink()
 
         with patch(
-                "services.collaborator_service.get_active_dossiers",
-                return_value={"clients": [], "contracts": [], "events": []},
+            "services.collaborator_service.get_active_dossiers",
+            return_value={"clients": [], "contracts": [], "events": []},
         ):
             deactivate_collaborator(
                 session=session,

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -364,7 +364,6 @@ class TestDeactivateCollaborator:
     ):
         """Collaborator is deactivated when no active dossiers exist."""
         collaborator = make_collaborator(id=42, is_active=True)
-
         session = MagicMock()
 
         with patch(
@@ -388,10 +387,7 @@ class TestDeactivateCollaborator:
     ):
         """Session file is deleted if it exists."""
         collaborator = make_collaborator(id=42)
-
-        # Create the file
         session_file.write_text("token")
-
         session = MagicMock()
 
         with patch(
@@ -424,7 +420,7 @@ class TestDeactivateCollaborator:
         make_collaborator,
         dossiers,
     ):
-        """Raises ReassignmentRequiredError if any type of dossier exists."""
+        """Raises ReassignmentRequiredError with dossiers details if any exist."""
         collaborator = make_collaborator(id=42)
         session = MagicMock()
 
@@ -432,13 +428,14 @@ class TestDeactivateCollaborator:
             "services.collaborator_service.get_active_dossiers",
             return_value=dossiers,
         ):
-            with pytest.raises(ReassignmentRequiredError):
+            with pytest.raises(ReassignmentRequiredError) as exc_info:
                 deactivate_collaborator(
                     session=session,
                     current_user=management_user,
                     collaborator=collaborator,
                 )
-
+        # The exception should carry the exact dossiers dict
+        assert exc_info.value.dossiers == dossiers
         session.commit.assert_not_called()
 
     def test_no_error_if_session_file_missing(
@@ -449,7 +446,6 @@ class TestDeactivateCollaborator:
     ):
         """No error occurs if session file does not exist."""
         collaborator = make_collaborator(id=42)
-
         session = MagicMock()
 
         # Ensure file does not exist

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -11,12 +11,14 @@ Tests are organised by function:
 from unittest.mock import MagicMock
 
 import pytest
+from unittest.mock import patch
 
-from exceptions import DuplicateEmailError, PermissionDeniedError
+from exceptions import DuplicateEmailError, PermissionDeniedError, ReassignmentRequiredError
 from services.collaborator_service import (
     create_collaborator,
     update_collaborator,
-    get_active_dossiers
+    get_active_dossiers,
+    deactivate_collaborator,
 )
 from models.contract import ContractStatus
 
@@ -348,3 +350,39 @@ class TestGetActiveDossiers:
         result = get_active_dossiers(session=session, collaborator=collaborator)
 
         assert active_event in result["events"]
+
+class TestDeactivateCollaborator:
+    """Tests for the deactivate_collaborator service function."""
+
+    # ---------------------------
+    # Happy path
+    # ---------------------------
+
+    def test_deactivates_collaborator_when_no_dossiers(
+            self,
+            management_user,
+            make_collaborator,
+    ):
+        """Collaborator is deactivated when no active dossiers exist."""
+
+        collaborator = make_collaborator(id=42, is_active=True)
+
+        session = MagicMock()
+
+        with patch(
+                "services.collaborator_service.get_active_dossiers",
+                return_value={"clients": [], "contracts": [], "events": []},
+        ):
+            deactivate_collaborator(
+                session=session,
+                current_user=management_user,
+                collaborator=collaborator,
+            )
+
+        assert collaborator.is_active is False
+        session.commit.assert_called_once()
+
+    # ---------------------------
+    # Sad path
+    # ---------------------------
+

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -445,3 +445,32 @@ class TestDeactivateCollaborator:
                 )
 
         session.commit.assert_not_called()
+
+    def test_no_error_if_session_file_missing(
+            self,
+            management_user,
+            make_collaborator,
+            session_file,
+    ):
+        """No error occurs if session file does not exist."""
+
+        collaborator = make_collaborator(id=42)
+
+        session = MagicMock()
+
+        # Ensure file does not exist
+        if session_file.exists():
+            session_file.unlink()
+
+        with patch(
+                "services.collaborator_service.get_active_dossiers",
+                return_value={"clients": [], "contracts": [], "events": []},
+        ):
+            deactivate_collaborator(
+                session=session,
+                current_user=management_user,
+                collaborator=collaborator,
+            )
+
+        # If no exception → test passes
+        session.commit.assert_called_once()

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -13,7 +13,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from exceptions import DuplicateEmailError, PermissionDeniedError
-from services.collaborator_service import create_collaborator, update_collaborator
+from services.collaborator_service import (
+    create_collaborator,
+    update_collaborator,
+    get_active_dossiers
+)
 
 
 class TestCreateCollaborator:
@@ -197,3 +201,44 @@ class TestUpdateCollaborator:
                 collaborator=target,
                 first_name="Robert",
             )
+
+
+class TestGetActiveDossiers:
+    """Tests for helper that retrieves active dossiers for a collaborator."""
+
+    def test_returns_all_active_dossiers(
+        self,
+        make_collaborator,
+        make_client,
+        make_contract,
+        make_event,
+    ):
+        """Returns clients, contracts, and events linked to collaborator."""
+
+        # ── Arrange ────────────────────────────────────────────────
+        collaborator = make_collaborator(id=42)
+
+        # Fake data returned by queries
+        clients = [make_client(id=1, commercial_id=42)]
+        contracts = [
+            make_contract(id=1, commercial_id=42),
+            make_contract(id=2, commercial_id=42),
+        ]
+        events = [make_event(id=1, support_id=42)]
+
+        session = MagicMock()
+
+        # Mock query chains in order of calls
+        session.query.return_value.filter.return_value.all.side_effect = [
+            clients,    # first call → clients
+            contracts,  # second call → contracts
+            events,     # third call → events
+        ]
+
+        # ── Act ────────────────────────────────────────────────────
+        result = get_active_dossiers(session=session, collaborator=collaborator)
+
+        # ── Assert ─────────────────────────────────────────────────
+        assert result["clients"] == clients
+        assert result["contracts"] == contracts
+        assert result["events"] == events

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -14,6 +14,7 @@ import pytest
 from unittest.mock import patch
 
 from exceptions import DuplicateEmailError, PermissionDeniedError, ReassignmentRequiredError
+from services.auth_service import settings
 from services.collaborator_service import (
     create_collaborator,
     update_collaborator,
@@ -381,6 +382,33 @@ class TestDeactivateCollaborator:
 
         assert collaborator.is_active is False
         session.commit.assert_called_once()
+
+    def test_session_file_deleted_on_deactivation(
+            self,
+            management_user,
+            make_collaborator,
+            session_file,
+    ):
+        """Session file is deleted if it exists."""
+
+        collaborator = make_collaborator(id=42)
+
+        # Create the file
+        session_file.write_text("token")
+
+        session = MagicMock()
+
+        with patch(
+                "services.collaborator_service.get_active_dossiers",
+                return_value={"clients": [], "contracts": [], "events": []},
+        ):
+            deactivate_collaborator(
+                session=session,
+                current_user=management_user,
+                collaborator=collaborator,
+            )
+
+        assert not session_file.exists()
 
     # ---------------------------
     # Sad path

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -386,3 +386,34 @@ class TestDeactivateCollaborator:
     # Sad path
     # ---------------------------
 
+    @pytest.mark.parametrize(
+        "dossiers",
+        [
+            {"clients": ["client"], "contracts": [], "events": []},
+            {"clients": [], "contracts": ["contract"], "events": []},
+            {"clients": [], "contracts": [], "events": ["event"]},
+        ],
+    )
+    def test_raises_if_any_active_dossier_exists(
+            self,
+            management_user,
+            make_collaborator,
+            dossiers,
+    ):
+        """Raises ReassignmentRequiredError if any type of dossier exists."""
+
+        collaborator = make_collaborator(id=42)
+        session = MagicMock()
+
+        with patch(
+                "services.collaborator_service.get_active_dossiers",
+                return_value=dossiers,
+        ):
+            with pytest.raises(ReassignmentRequiredError):
+                deactivate_collaborator(
+                    session=session,
+                    current_user=management_user,
+                    collaborator=collaborator,
+                )
+
+        session.commit.assert_not_called()


### PR DESCRIPTION
## Summary
This PR implements **collaborator deactivation** for managers while enforcing that **all active dossiers must be reassigned** before deactivation, in line with US-20.

---

## ✅ Changes

**`services/collaborator_service.py`**  
- Added `get_active_dossiers()` helper to retrieve active:
  - **Clients** (`commercial_id == collaborator.id`)  
  - **Contracts** (`commercial_id == collaborator.id` AND status NOT IN CANCELLED / PAID_IN_FULL)  
  - **Events** (`support_id == collaborator.id` AND `is_cancelled == False`)  
- Updated `deactivate_collaborator()` to:
  - Raise `ReassignmentRequiredError(dossiers=dossiers)` if any active dossiers exist.  
  - Set `is_active = False` if no active dossiers remain.  
  - Delete session file if it exists (`settings.session_file`).  
  - Commit changes to the database.

**`exceptions.py`**  
- `ReassignmentRequiredError` now optionally carries the `dossiers` dict for structured error reporting.

**Unit Tests**  
- **Happy path**: collaborator with no active dossiers → deactivated, session file deleted.  
- **Sad paths**: 
  - Active client → raises `ReassignmentRequiredError`  
  - Active contract → raises `ReassignmentRequiredError`  
  - Active event → raises `ReassignmentRequiredError`  
- Test for missing session file → no error raised, deactivation proceeds.  
- Parametrized tests verify all dossier types.

**Permissions**  
- `@require_role("MANAGEMENT")` ensures only managers can deactivate collaborators.

---

## ✅ Acceptance Criteria Covered

- [x] Management role required → `PermissionDeniedError` enforced by decorator  
- [x] Active dossiers queried correctly (clients, contracts, events)  
- [x] `ReassignmentRequiredError` raised if active dossiers exist  
- [x] Deactivation only occurs when all dossiers reassigned  
- [x] On completion: `is_active = False`, session file deleted if exists  
- [x] Deactivated collaborator login blocked → `AuthenticationError` (already in US-12)

---

## Notes / Next Steps

- CLI/UI can now display structured messages from `ReassignmentRequiredError`, e.g.:  
  - `"2 clients still assigned"`  
  - `"1 active contract remaining"`  

- Optional improvement: enhance CLI/UI to parse `dossiers` for detailed user guidance.

Closes #25 