### PR TITLE
feat(collaborator): implement get_collaborators with filters — closes #26

### DIFF
--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -275,5 +275,8 @@ def get_collaborators(
     if role is not None:
         query = query.join(Role).filter(Role.name == role)
 
+    if is_active is not None:
+        query = query.filter(Collaborator.is_active == is_active)
+
     results: list[Collaborator] = query.all()  # type: ignore[assignment]
     return results

--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -13,9 +13,9 @@ from sqlalchemy.orm import Session
 from exceptions import DuplicateEmailError, ReassignmentRequiredError
 from models.client import Client
 from models.collaborator import Collaborator
-from models.role import Role
 from models.contract import Contract, ContractStatus
 from models.event import Event
+from models.role import Role
 from permissions.decorators import require_role
 from services.auth_service import _delete_session_file
 
@@ -248,12 +248,13 @@ def deactivate_collaborator(
     # Step 5 — persist changes
     session.commit()
 
+
 @require_role("MANAGEMENT")
 def get_collaborators(
-        session: Session,
-        current_user: Collaborator,  # noqa: ARG001 — consumed by @require_role
-        role: str | None = None,
-        is_active: bool | None = None,
+    session: Session,
+    current_user: Collaborator,  # noqa: ARG001 — consumed by @require_role
+    role: str | None = None,
+    is_active: bool | None = None,
 ) -> list[Collaborator]:
     """
     Return all collaborators, optionally filtered by role or active status.

--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from exceptions import DuplicateEmailError, ReassignmentRequiredError
 from models.client import Client
 from models.collaborator import Collaborator
+from models.role import Role
 from models.contract import Contract, ContractStatus
 from models.event import Event
 from permissions.decorators import require_role
@@ -269,5 +270,10 @@ def get_collaborators(
     Raises:
         PermissionDeniedError: If current_user is not Management.
     """
-    results: list[Collaborator] = session.query(Collaborator).all()  # type: ignore[assignment]
+    query = session.query(Collaborator)
+
+    if role is not None:
+        query = query.join(Role).filter(Role.name == role)
+
+    results: list[Collaborator] = query.all()  # type: ignore[assignment]
     return results

--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -246,3 +246,28 @@ def deactivate_collaborator(
 
     # Step 5 — persist changes
     session.commit()
+
+@require_role("MANAGEMENT")
+def get_collaborators(
+        session: Session,
+        current_user: Collaborator,  # noqa: ARG001 — consumed by @require_role
+        role: str | None = None,
+        is_active: bool | None = None,
+) -> list[Collaborator]:
+    """
+    Return all collaborators, optionally filtered by role or active status.
+
+    Args:
+        session: SQLAlchemy database session.
+        current_user: The authenticated Management collaborator.
+        role: Optional role name to filter by e.g. 'MANAGEMENT'.
+        is_active: Optional active status filter.
+
+    Returns:
+        list[Collaborator]: Matching collaborators.
+
+    Raises:
+        PermissionDeniedError: If current_user is not Management.
+    """
+    results: list[Collaborator] = session.query(Collaborator).all()  # type: ignore[assignment]
+    return results

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -23,6 +23,7 @@ from services.collaborator_service import (
     deactivate_collaborator,
     get_active_dossiers,
     update_collaborator,
+    get_collaborators,
 )
 
 
@@ -440,3 +441,28 @@ class TestDeactivateCollaborator:
 
         # If no exception → test passes
         session.commit.assert_called_once()
+
+class TestGetCollaborators:
+    """Tests for the get_collaborators function."""
+
+    # ---------------------------
+    # Happy path
+    # ---------------------------
+
+    def test_no_filters_returns_all_collaborators(
+            self, management_user, make_collaborator, management_role, commercial_role
+    ):
+        """No filters returns all collaborators."""
+        collaborators = [
+            make_collaborator(id=1, role=management_role),
+            make_collaborator(id=2, role=commercial_role),
+        ]
+        session = MagicMock()
+        session.query.return_value.all.return_value = collaborators
+
+        result = get_collaborators(
+            session=session,
+            current_user=management_user,
+        )
+
+        assert result == collaborators

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -520,3 +520,30 @@ class TestGetCollaborators:
                 session=session,
                 current_user=commercial_user,
             )
+
+    def test_combined_filters_returns_matching_collaborators(
+            self, management_user, make_collaborator, management_role
+    ):
+        """Role and is_active filters can be combined."""
+        active_manager = make_collaborator(
+            id=1,
+            role=management_role,
+            is_active=True,
+        )
+
+        session = MagicMock()
+        (session.query.return_value.join.return_value.
+         filter.return_value.filter.return_value.all).return_value = [
+            active_manager
+        ]
+
+        result = get_collaborators(
+            session=session,
+            current_user=management_user,
+            role="MANAGEMENT",
+            is_active=True,
+        )
+
+        assert len(result) == 1
+        assert result[0].role.name == "MANAGEMENT"
+        assert result[0].is_active is True

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -22,8 +22,8 @@ from services.collaborator_service import (
     create_collaborator,
     deactivate_collaborator,
     get_active_dossiers,
-    update_collaborator,
     get_collaborators,
+    update_collaborator,
 )
 
 
@@ -442,6 +442,7 @@ class TestDeactivateCollaborator:
         # If no exception → test passes
         session.commit.assert_called_once()
 
+
 class TestGetCollaborators:
     """Tests for the get_collaborators function."""
 
@@ -450,7 +451,7 @@ class TestGetCollaborators:
     # ---------------------------
 
     def test_no_filters_returns_all_collaborators(
-            self, management_user, make_collaborator, management_role, commercial_role
+        self, management_user, make_collaborator, management_role, commercial_role
     ):
         """No filters returns all collaborators."""
         collaborators = [
@@ -468,15 +469,19 @@ class TestGetCollaborators:
         assert result == collaborators
 
     def test_filter_by_role_returns_matching_collaborators(
-            self, management_user, make_collaborator, management_role, commercial_role
+        self, management_user, make_collaborator, management_role
     ):
         """Filter by role returns only collaborators with that role."""
         management_collaborator = make_collaborator(id=1, role=management_role)
 
         session = MagicMock()
-        session.query.return_value.join.return_value.filter.return_value.all.return_value = [
-            management_collaborator
-        ]
+        mock_query = (
+            session.query.return_value
+            .join.return_value
+            .filter.return_value
+            .all
+        )
+        mock_query.return_value = [management_collaborator]
 
         result = get_collaborators(
             session=session,
@@ -488,7 +493,7 @@ class TestGetCollaborators:
         assert result[0].role.name == "MANAGEMENT"
 
     def test_filter_by_is_active_returns_matching_collaborators(
-            self, management_user, make_collaborator, management_role
+        self, management_user, make_collaborator, management_role
     ):
         """Filter by is_active returns only collaborators with that status."""
         inactive_collaborator = make_collaborator(
@@ -511,18 +516,8 @@ class TestGetCollaborators:
         assert len(result) == 1
         assert result[0].is_active is False
 
-    def test_non_management_caller_raises(self, commercial_user):
-        """Non-Management caller raises PermissionDeniedError."""
-        session = MagicMock()
-
-        with pytest.raises(PermissionDeniedError):
-            get_collaborators(
-                session=session,
-                current_user=commercial_user,
-            )
-
     def test_combined_filters_returns_matching_collaborators(
-            self, management_user, make_collaborator, management_role
+        self, management_user, make_collaborator, management_role
     ):
         """Role and is_active filters can be combined."""
         active_manager = make_collaborator(
@@ -551,3 +546,17 @@ class TestGetCollaborators:
         assert len(result) == 1
         assert result[0].role.name == "MANAGEMENT"
         assert result[0].is_active is True
+
+    # ---------------------------
+    # Sad path
+    # ---------------------------
+
+    def test_non_management_caller_raises(self, commercial_user):
+        """Non-Management caller raises PermissionDeniedError."""
+        session = MagicMock()
+
+        with pytest.raises(PermissionDeniedError):
+            get_collaborators(
+                session=session,
+                current_user=commercial_user,
+            )

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -466,3 +466,23 @@ class TestGetCollaborators:
         )
 
         assert result == collaborators
+
+    def test_filter_by_role_returns_matching_collaborators(
+            self, management_user, make_collaborator, management_role, commercial_role
+    ):
+        """Filter by role returns only collaborators with that role."""
+        management_collaborator = make_collaborator(id=1, role=management_role)
+
+        session = MagicMock()
+        session.query.return_value.join.return_value.filter.return_value.all.return_value = [
+            management_collaborator
+        ]
+
+        result = get_collaborators(
+            session=session,
+            current_user=management_user,
+            role="MANAGEMENT",
+        )
+
+        assert len(result) == 1
+        assert result[0].role.name == "MANAGEMENT"

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -532,10 +532,14 @@ class TestGetCollaborators:
         )
 
         session = MagicMock()
-        (session.query.return_value.join.return_value.
-         filter.return_value.filter.return_value.all).return_value = [
-            active_manager
-        ]
+        mock_query = (
+            session.query.return_value
+            .join.return_value
+            .filter.return_value
+            .filter.return_value
+            .all
+        )
+        mock_query.return_value = [active_manager]
 
         result = get_collaborators(
             session=session,

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -525,11 +525,7 @@ class TestGetCollaborators:
 
         session = MagicMock()
         mock_query = (
-            session.query.return_value
-            .join.return_value
-            .filter.return_value
-            .filter.return_value
-            .all
+            session.query.return_value.join.return_value.filter.return_value.filter.return_value.all
         )
         mock_query.return_value = [active_manager]
 

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -476,10 +476,7 @@ class TestGetCollaborators:
 
         session = MagicMock()
         mock_query = (
-            session.query.return_value
-            .join.return_value
-            .filter.return_value
-            .all
+            session.query.return_value.join.return_value.filter.return_value.all
         )
         mock_query.return_value = [management_collaborator]
 

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -486,3 +486,27 @@ class TestGetCollaborators:
 
         assert len(result) == 1
         assert result[0].role.name == "MANAGEMENT"
+
+    def test_filter_by_is_active_returns_matching_collaborators(
+            self, management_user, make_collaborator, management_role
+    ):
+        """Filter by is_active returns only collaborators with that status."""
+        inactive_collaborator = make_collaborator(
+            id=4,
+            role=management_role,
+            is_active=False,
+        )
+
+        session = MagicMock()
+        session.query.return_value.filter.return_value.all.return_value = [
+            inactive_collaborator
+        ]
+
+        result = get_collaborators(
+            session=session,
+            current_user=management_user,
+            is_active=False,
+        )
+
+        assert len(result) == 1
+        assert result[0].is_active is False

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -525,11 +525,7 @@ class TestGetCollaborators:
 
         session = MagicMock()
         mock_query = (
-            session.query.return_value
-            .join.return_value
-            .filter.return_value
-            .filter.return_value
-            .all
+            session.query.return_value.join.return_value.filter.return_value.filter.return_value.all  # noqa: E501
         )
         mock_query.return_value = [active_manager]
 

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -510,3 +510,13 @@ class TestGetCollaborators:
 
         assert len(result) == 1
         assert result[0].is_active is False
+
+    def test_non_management_caller_raises(self, commercial_user):
+        """Non-Management caller raises PermissionDeniedError."""
+        session = MagicMock()
+
+        with pytest.raises(PermissionDeniedError):
+            get_collaborators(
+                session=session,
+                current_user=commercial_user,
+            )

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -525,7 +525,11 @@ class TestGetCollaborators:
 
         session = MagicMock()
         mock_query = (
-            session.query.return_value.join.return_value.filter.return_value.filter.return_value.all
+            session.query.return_value
+            .join.return_value
+            .filter.return_value
+            .filter.return_value
+            .all
         )
         mock_query.return_value = [active_manager]
 


### PR DESCRIPTION
## Summary

Implements `get_collaborators()` in `services/collaborator_service.py`,
completing US-22.

Closes #26 (US-22 — View and filter collaborator list)

---

## What was delivered

- `get_collaborators()` — returns all collaborators scoped to Management
  role, with optional filters for role name and active status
- Role filter joins the Role table and filters by `Role.name`
- Active status filter applies `Collaborator.is_active == is_active`
- Filters can be combined — both applied in sequence on the same query
- Empty result returns an empty list — view layer handles display in
  Sprint 4

---

## Tests

- No filters → all collaborators returned
- Filter by role → only matching role returned
- Filter by is_active = False → only inactive returned
- Combined filters → correct results returned
- Non-Management caller → PermissionDeniedError