### PR TITLE
feat(collaborator): implement get_collaborator_by_id — closes #27

### DIFF
--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 from exceptions import (
     CollaboratorNotFoundError,
     DuplicateEmailError,
-    ReassignmentRequiredError
+    ReassignmentRequiredError,
 )
 from models.client import Client
 from models.collaborator import Collaborator
@@ -307,8 +307,6 @@ def get_collaborator_by_id(
         PermissionDeniedError: If current_user is not Management.
         CollaboratorNotFoundError: If no collaborator exists with that ID.
     """
-    from exceptions import CollaboratorNotFoundError
-
     collaborator: Collaborator | None = session.get(Collaborator, collaborator_id)
 
     if not collaborator:

--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 
 from sqlalchemy.orm import Session
 
-from exceptions import DuplicateEmailError, ReassignmentRequiredError
+from exceptions import (
+    CollaboratorNotFoundError,
+    DuplicateEmailError,
+    ReassignmentRequiredError
+)
 from models.client import Client
 from models.collaborator import Collaborator
 from models.contract import Contract, ContractStatus
@@ -281,3 +285,35 @@ def get_collaborators(
 
     results: list[Collaborator] = query.all()  # type: ignore[assignment]
     return results
+
+
+@require_role("MANAGEMENT")
+def get_collaborator_by_id(
+    session: Session,
+    current_user: Collaborator,  # noqa: ARG001 — consumed by @require_role
+    collaborator_id: int,
+) -> Collaborator:
+    """Return a single collaborator by ID.
+
+    Args:
+        session: SQLAlchemy database session.
+        current_user: The authenticated Management collaborator.
+        collaborator_id: The primary key of the collaborator to retrieve.
+
+    Returns:
+        Collaborator: The matching collaborator instance.
+
+    Raises:
+        PermissionDeniedError: If current_user is not Management.
+        CollaboratorNotFoundError: If no collaborator exists with that ID.
+    """
+    from exceptions import CollaboratorNotFoundError
+
+    collaborator: Collaborator | None = session.get(Collaborator, collaborator_id)
+
+    if not collaborator:
+        raise CollaboratorNotFoundError(
+            f"No collaborator found with ID {collaborator_id}."
+        )
+
+    return collaborator

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from exceptions import (
+    CollaboratorNotFoundError,
     DuplicateEmailError,
     PermissionDeniedError,
     ReassignmentRequiredError,
@@ -23,6 +24,7 @@ from services.collaborator_service import (
     deactivate_collaborator,
     get_active_dossiers,
     get_collaborators,
+    get_collaborator_by_id,
     update_collaborator,
 )
 
@@ -553,3 +555,29 @@ class TestGetCollaborators:
                 session=session,
                 current_user=commercial_user,
             )
+
+
+class TestGetCollaboratorById:
+    """Tests for the get_collaborator_by_id service function."""
+
+    # ---------------------------
+    # Happy path
+    # ---------------------------
+
+    def test_valid_id_returns_collaborator(
+        self, management_user, make_collaborator, management_role
+    ):
+        """Valid ID returns the correct collaborator."""
+        target = make_collaborator(id=2, role=management_role)
+
+        session = MagicMock()
+        session.get.return_value = target
+
+        result = get_collaborator_by_id(
+            session=session,
+            current_user=management_user,
+            collaborator_id=2,
+        )
+
+        assert result == target
+        assert result.id == 2

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -581,3 +581,19 @@ class TestGetCollaboratorById:
 
         assert result == target
         assert result.id == 2
+
+    # ---------------------------
+    # Sad path
+    # ---------------------------
+
+    def test_invalid_id_raises(self, management_user):
+        """Invalid ID raises CollaboratorNotFoundError."""
+        session = MagicMock()
+        session.get.return_value = None
+
+        with pytest.raises(CollaboratorNotFoundError):
+            get_collaborator_by_id(
+                session=session,
+                current_user=management_user,
+                collaborator_id=999,
+            )

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -597,3 +597,14 @@ class TestGetCollaboratorById:
                 current_user=management_user,
                 collaborator_id=999,
             )
+
+    def test_non_management_caller_raises(self, commercial_user):
+        """Non-Management caller raises PermissionDeniedError."""
+        session = MagicMock()
+
+        with pytest.raises(PermissionDeniedError):
+            get_collaborator_by_id(
+                session=session,
+                current_user=commercial_user,
+                collaborator_id=1,
+            )

--- a/tests/unit/services/test_collaborator_service.py
+++ b/tests/unit/services/test_collaborator_service.py
@@ -23,8 +23,8 @@ from services.collaborator_service import (
     create_collaborator,
     deactivate_collaborator,
     get_active_dossiers,
-    get_collaborators,
     get_collaborator_by_id,
+    get_collaborators,
     update_collaborator,
 )
 


### PR DESCRIPTION
## Summary

Implements `get_collaborator_by_id()` in `services/collaborator_service.py`,
completing US-25.

Closes #27 (US-25 — View single collaborator detail)

---

## What was delivered

- `get_collaborator_by_id()` — retrieves a single collaborator by primary
  key, raises CollaboratorNotFoundError if not found
- Management role enforced via `@require_role("MANAGEMENT")`
- `CollaboratorNotFoundError` moved to top-level imports in service file

---

## Tests

- Valid ID → correct collaborator returned
- Invalid ID → CollaboratorNotFoundError
- Non-Management caller → PermissionDeniedError