### PR TITLE
feat(client): implement create_client service — closes #36

### DIFF
--- a/services/client_service.py
+++ b/services/client_service.py
@@ -1,0 +1,74 @@
+"""
+Client service.
+
+Handles all client management operations — creation, update,
+deactivation, and retrieval.
+
+For creation/update, this requires a 'Commercial' role.
+All others have Read access and typically scoped to their role/permissions.
+Ex. Management can view all clients, but Support can only view clients assigned
+to them.
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from exceptions import DuplicateEmailError
+from models.collaborator import Collaborator
+from models.client import Client
+from permissions.decorators import require_role
+from utils.validation import validate_email
+
+@require_role("COMMERCIAL")
+def create_client(
+        session: Session,
+        current_user: Collaborator,
+        first_name: str,
+        last_name: str,
+        email: str,
+        phone: str | None = None,
+        company_name: str | None = None,
+
+) -> Client:
+    """Create a new client profile.
+
+    Args:
+        session: SQLAlchemy database session.
+        current_user: The authenticated Commercial collaborator.
+        first_name: Client's first name.
+        last_name: Client's last name.
+        email: Client's email address — must be unique.
+        phone: Optional phone number.
+        company_name: Optional company name.
+
+    Returns:
+        Client: The newly created client instance.
+
+    Raises:
+        PermissionDeniedError: If current_user is not Commercial.
+        DuplicateEmailError: If email already exists.
+        ValidationError: If email format is invalid.
+    """
+    # Step 1 — validate email format
+    validate_email(email)
+
+    # Step 2 — check email uniqueness
+    existing = session.query(Client).filter_by(email=email).first()
+    if existing:
+        raise DuplicateEmailError(
+            f"A client with email '{email}' already exists."
+        )
+
+    # Step 3 - build client
+    client = Client()
+    client.first_name = first_name
+    client.last_name = last_name
+    client.email = email
+    client.phone = phone
+    client.company_name = company_name
+    client.commercial_id = current_user.id
+
+    session.add(client)
+    session.commit()
+
+    return client

--- a/services/client_service.py
+++ b/services/client_service.py
@@ -9,26 +9,27 @@ All others have Read access and typically scoped to their role/permissions.
 Ex. Management can view all clients, but Support can only view clients assigned
 to them.
 """
+
 from __future__ import annotations
 
 from sqlalchemy.orm import Session
 
 from exceptions import DuplicateEmailError
-from models.collaborator import Collaborator
 from models.client import Client
+from models.collaborator import Collaborator
 from permissions.decorators import require_role
 from utils.validation import validate_email
 
+
 @require_role("COMMERCIAL")
 def create_client(
-        session: Session,
-        current_user: Collaborator,
-        first_name: str,
-        last_name: str,
-        email: str,
-        phone: str | None = None,
-        company_name: str | None = None,
-
+    session: Session,
+    current_user: Collaborator,
+    first_name: str,
+    last_name: str,
+    email: str,
+    phone: str | None = None,
+    company_name: str | None = None,
 ) -> Client:
     """Create a new client profile.
 
@@ -55,9 +56,7 @@ def create_client(
     # Step 2 — check email uniqueness
     existing = session.query(Client).filter_by(email=email).first()
     if existing:
-        raise DuplicateEmailError(
-            f"A client with email '{email}' already exists."
-        )
+        raise DuplicateEmailError(f"A client with email '{email}' already exists.")
 
     # Step 3 - build client
     client = Client()

--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -26,6 +26,7 @@ from utils.validation import validate_email
 
 # ── Collaborator helpers ─────────────────────────────────────────────────────
 
+
 def _generate_employee_number(session: Session) -> str:
     """Generate the next sequential employee number.
 

--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -8,15 +8,12 @@ via the @require_role decorator.
 
 from __future__ import annotations
 
-import re
-
 from sqlalchemy.orm import Session, joinedload
 
 from exceptions import (
     CollaboratorNotFoundError,
     DuplicateEmailError,
     ReassignmentRequiredError,
-    ValidationError,
 )
 from models.client import Client
 from models.collaborator import Collaborator
@@ -25,26 +22,9 @@ from models.event import Event
 from models.role import Role
 from permissions.decorators import require_role
 from services.auth_service import _delete_session_file
+from utils.validation import validate_email
 
 # ── Collaborator helpers ─────────────────────────────────────────────────────
-
-
-def _validate_email(email: str) -> None:
-    """Validate that an email address has a minimally correct format.
-
-    Checks for presence of @ and a dot in the domain portion.
-    Does not perform DNS lookup or full RFC 5322 validation.
-
-    Args:
-        email: The email string to validate.
-
-    Raises:
-        ValidationError: If the email format is invalid or empty.
-    """
-    pattern = r"^[^@\s]+@[^@\s]+\.[^@\s]+$"
-    if not email or not re.match(pattern, email.strip()):
-        raise ValidationError(f"'{email}' is not a valid email address.")
-
 
 def _generate_employee_number(session: Session) -> str:
     """Generate the next sequential employee number.
@@ -159,7 +139,7 @@ def create_collaborator(
         DuplicateEmailError: If email already exists.
     """
     # Step 1 - validate email with regex
-    _validate_email(email)
+    validate_email(email)
 
     # Step 2 — check email uniqueness
     existing = session.query(Collaborator).filter_by(email=email).first()
@@ -226,7 +206,7 @@ def update_collaborator(
         collaborator.last_name = last_name
 
     if email is not None:
-        _validate_email(email)
+        validate_email(email)
         existing = session.query(Collaborator).filter_by(email=email).first()
         if existing and existing.id != collaborator.id:
             raise DuplicateEmailError(

--- a/tests/unit/services/test_client_service.py
+++ b/tests/unit/services/test_client_service.py
@@ -1,0 +1,108 @@
+"""Unit tests for the client service.
+
+Tests are organised by function:
+    - create_client
+
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from exceptions import (
+    PermissionDeniedError,
+    DuplicateEmailError,
+    ValidationError,
+)
+from services.client_service import (
+    create_client,
+)
+
+class TestWriteClientService:
+    """Tests for client write operations — create and update."""
+
+    # ---------------------------
+    # create_client — happy path
+    # ---------------------------
+
+    def test_create_client_sets_commercial_id_from_current_user(
+            self, commercial_user, mock_session_empty
+    ):
+        """Client is created with commercial_id set from current_user.id."""
+        result = create_client(
+            session=mock_session_empty,
+            current_user=commercial_user,
+            first_name="Marie",
+            last_name="Curie",
+            email="marie.curie@example.com",
+        )
+
+        assert result.commercial_id == commercial_user.id
+        assert result.first_name == "Marie"
+        assert result.last_name == "Curie"
+        mock_session_empty.add.assert_called_once()
+        mock_session_empty.commit.assert_called_once()
+
+
+    # ---------------------------
+    # create_client — sad path
+    # ---------------------------
+
+    def test_client_invalid_email_raises(
+            self, commercial_user, mock_session_empty
+    ):
+        """Invalid email format raises ValidationError."""
+        with pytest.raises(ValidationError):
+            create_client(
+                session=mock_session_empty,
+                current_user=commercial_user,
+                first_name="Marie",
+                last_name="Curie",
+                email="notanemail",
+            )
+
+    def test_create_client_duplicate_email_raises(
+            self, commercial_user
+    ):
+        """Duplicate email raises DuplicateEmailError."""
+        session = MagicMock()
+        session.query.return_value.filter_by.return_value.first.return_value = MagicMock()
+
+        with pytest.raises(DuplicateEmailError):
+            create_client(
+                session=session,
+                current_user=commercial_user,
+                first_name="Marie",
+                last_name="Curie",
+                email="already.exists@example.com",
+            )
+
+    def test_create_client_non_commercial_caller_raises(
+            self, management_user
+    ):
+        """Non-Commercial caller raises PermissionDeniedError."""
+        session = MagicMock()
+
+        with pytest.raises(PermissionDeniedError):
+            create_client(
+                session=session,
+                current_user=management_user,
+                first_name="Marie",
+                last_name="Curie",
+                email="marie.curie@example.com",
+            )
+
+    def test_create_client_commercial_id_cannot_be_overridden(
+            self, commercial_user, mock_session_empty
+    ):
+        """commercial_id is always set from current_user.id regardless of input."""
+        result = create_client(
+            session=mock_session_empty,
+            current_user=commercial_user,
+            first_name="Marie",
+            last_name="Curie",
+            email="marie.curie@example.com",
+        )
+
+        assert result.commercial_id == commercial_user.id
+        assert result.commercial_id != 999

--- a/tests/unit/services/test_client_service.py
+++ b/tests/unit/services/test_client_service.py
@@ -10,13 +10,14 @@ from unittest.mock import MagicMock
 import pytest
 
 from exceptions import (
-    PermissionDeniedError,
     DuplicateEmailError,
+    PermissionDeniedError,
     ValidationError,
 )
 from services.client_service import (
     create_client,
 )
+
 
 class TestWriteClientService:
     """Tests for client write operations — create and update."""
@@ -26,7 +27,7 @@ class TestWriteClientService:
     # ---------------------------
 
     def test_create_client_sets_commercial_id_from_current_user(
-            self, commercial_user, mock_session_empty
+        self, commercial_user, mock_session_empty
     ):
         """Client is created with commercial_id set from current_user.id."""
         result = create_client(
@@ -43,14 +44,11 @@ class TestWriteClientService:
         mock_session_empty.add.assert_called_once()
         mock_session_empty.commit.assert_called_once()
 
-
     # ---------------------------
     # create_client — sad path
     # ---------------------------
 
-    def test_client_invalid_email_raises(
-            self, commercial_user, mock_session_empty
-    ):
+    def test_client_invalid_email_raises(self, commercial_user, mock_session_empty):
         """Invalid email format raises ValidationError."""
         with pytest.raises(ValidationError):
             create_client(
@@ -61,12 +59,12 @@ class TestWriteClientService:
                 email="notanemail",
             )
 
-    def test_create_client_duplicate_email_raises(
-            self, commercial_user
-    ):
+    def test_create_client_duplicate_email_raises(self, commercial_user):
         """Duplicate email raises DuplicateEmailError."""
         session = MagicMock()
-        session.query.return_value.filter_by.return_value.first.return_value = MagicMock()
+        session.query.return_value.filter_by.return_value.first.return_value = (
+            MagicMock()
+        )
 
         with pytest.raises(DuplicateEmailError):
             create_client(
@@ -77,9 +75,7 @@ class TestWriteClientService:
                 email="already.exists@example.com",
             )
 
-    def test_create_client_non_commercial_caller_raises(
-            self, management_user
-    ):
+    def test_create_client_non_commercial_caller_raises(self, management_user):
         """Non-Commercial caller raises PermissionDeniedError."""
         session = MagicMock()
 
@@ -93,7 +89,7 @@ class TestWriteClientService:
             )
 
     def test_create_client_commercial_id_cannot_be_overridden(
-            self, commercial_user, mock_session_empty
+        self, commercial_user, mock_session_empty
     ):
         """commercial_id is always set from current_user.id regardless of input."""
         result = create_client(

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -26,6 +26,4 @@ def validate_email(email: str) -> None:
     """
     pattern = r"^[^@\s]+@[^@\s]+\.[^@\s]+$"
     if not email or not re.match(pattern, email.strip()):
-        raise ValidationError(
-            f"'{email}' is not a valid email address."
-        )
+        raise ValidationError(f"'{email}' is not a valid email address.")

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -1,0 +1,31 @@
+"""
+Shared validation utilities.
+
+These helpers are called by service functions before writing to the
+database. They raise ValidationError on invalid input.
+"""
+
+from __future__ import annotations
+
+import re
+
+from exceptions import ValidationError
+
+
+def validate_email(email: str) -> None:
+    """Validate that an email address has a minimally correct format.
+
+    Checks for presence of @ and a dot in the domain portion.
+    Does not perform DNS lookup or full RFC 5322 validation.
+
+    Args:
+        email: The email string to validate.
+
+    Raises:
+        ValidationError: If the email format is invalid or empty.
+    """
+    pattern = r"^[^@\s]+@[^@\s]+\.[^@\s]+$"
+    if not email or not re.match(pattern, email.strip()):
+        raise ValidationError(
+            f"'{email}' is not a valid email address."
+        )


### PR DESCRIPTION
## Summary

Implements `create_client()` in `services/client_service.py`,
completing US-06.

Closes #36 (US-06 — Create new client)

---

## What was delivered

- `create_client()` — validates email format, enforces email uniqueness,
  auto-sets `commercial_id` from `current_user.id` (cannot be overridden),
  commits new client to DB
- Email format validation via shared `utils/validation.py` helper
- `@require_role("COMMERCIAL")` enforced — Management and Support cannot
  create clients

---

## Tests

- Valid input → client created with correct `commercial_id`
- `commercial_id` always set from `current_user` — not overridable
- Duplicate email → `DuplicateEmailError`
- Invalid email format → `ValidationError`
- Non-Commercial caller → `PermissionDeniedError`

---

## Notes

`utils/validation.py` introduced as shared validation helper —
`validate_email()` is reused across both `client_service.py` and
`collaborator_service.py` to avoid duplication.