### PR TITLE
feat(client): implement update_client service — closes #37

### DIFF
--- a/services/client_service.py
+++ b/services/client_service.py
@@ -14,7 +14,10 @@ from __future__ import annotations
 
 from sqlalchemy.orm import Session
 
-from exceptions import DuplicateEmailError
+from exceptions import (
+    DuplicateEmailError,
+    PermissionDeniedError,
+)
 from models.client import Client
 from models.collaborator import Collaborator
 from permissions.decorators import require_role
@@ -58,7 +61,7 @@ def create_client(
     if existing:
         raise DuplicateEmailError(f"A client with email '{email}' already exists.")
 
-    # Step 3 - build client
+    # Step 3 — build client
     client = Client()
     client.first_name = first_name
     client.last_name = last_name
@@ -70,4 +73,64 @@ def create_client(
     session.add(client)
     session.commit()
 
+    return client
+
+
+@require_role("COMMERCIAL")
+def update_client(
+    session: Session,
+    current_user: Collaborator,
+    client: Client,
+    first_name: str | None = None,
+    last_name: str | None = None,
+    email: str | None = None,
+    phone: str | None = None,
+    company_name: str | None = None,
+) -> Client:
+    """Update an existing client profile.
+
+    Args:
+        session: SQLAlchemy database session.
+        current_user: The authenticated Commercial collaborator.
+        client: The Client instance to update.
+        first_name: New first name, or None to leave unchanged.
+        last_name: New last name, or None to leave unchanged.
+        email: New email address, or None to leave unchanged.
+        phone: New phone number, or None to leave unchanged.
+        company_name: New company name, or None to leave unchanged.
+
+    Returns:
+        Client: The updated client instance.
+
+    Raises:
+        PermissionDeniedError: If current_user is not Commercial or
+                               does not own this client.
+        DuplicateEmailError: If new email belongs to another client.
+        ValidationError: If email format is invalid.
+    """
+    # Step 1 — ownership check
+    if client.commercial_id != current_user.id:
+        raise PermissionDeniedError("You can only update your own clients.")
+
+    # Step 2 — apply updates
+    if first_name is not None:
+        client.first_name = first_name
+
+    if last_name is not None:
+        client.last_name = last_name
+
+    if email is not None:
+        validate_email(email)
+        existing = session.query(Client).filter_by(email=email).first()
+        if existing and existing.id != client.id:
+            raise DuplicateEmailError(f"A client with email '{email}' already exists.")
+        client.email = email
+
+    if phone is not None:
+        client.phone = phone
+
+    if company_name is not None:
+        client.company_name = company_name
+
+    session.commit()
     return client

--- a/tests/unit/services/test_client_service.py
+++ b/tests/unit/services/test_client_service.py
@@ -16,6 +16,7 @@ from exceptions import (
 )
 from services.client_service import (
     create_client,
+    update_client,
 )
 
 
@@ -48,17 +49,6 @@ class TestWriteClientService:
     # create_client — sad path
     # ---------------------------
 
-    def test_client_invalid_email_raises(self, commercial_user, mock_session_empty):
-        """Invalid email format raises ValidationError."""
-        with pytest.raises(ValidationError):
-            create_client(
-                session=mock_session_empty,
-                current_user=commercial_user,
-                first_name="Marie",
-                last_name="Curie",
-                email="notanemail",
-            )
-
     def test_create_client_duplicate_email_raises(self, commercial_user):
         """Duplicate email raises DuplicateEmailError."""
         session = MagicMock()
@@ -73,6 +63,19 @@ class TestWriteClientService:
                 first_name="Marie",
                 last_name="Curie",
                 email="already.exists@example.com",
+            )
+
+    def test_create_client_invalid_email_raises(
+        self, commercial_user, mock_session_empty
+    ):
+        """Invalid email format raises ValidationError."""
+        with pytest.raises(ValidationError):
+            create_client(
+                session=mock_session_empty,
+                current_user=commercial_user,
+                first_name="Marie",
+                last_name="Curie",
+                email="notanemail",
             )
 
     def test_create_client_non_commercial_caller_raises(self, management_user):
@@ -102,3 +105,124 @@ class TestWriteClientService:
 
         assert result.commercial_id == commercial_user.id
         assert result.commercial_id != 999
+
+    # ---------------------------
+    # update_client — happy path
+    # ---------------------------
+
+    def test_update_client_owner_can_update(self, commercial_user, make_client):
+        """Owner can update their own client."""
+        test_client = make_client(
+            id=1,
+            commercial_id=commercial_user.id,
+        )
+        session = MagicMock()
+        session.query.return_value.filter_by.return_value.first.return_value = None
+
+        result = update_client(
+            session=session,
+            current_user=commercial_user,
+            client=test_client,
+            first_name="Updated",
+        )
+
+        assert result.first_name == "Updated"
+        session.commit.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "field, value",
+        [
+            ("last_name", "Curie"),
+            ("phone", "0612345678"),
+            ("company_name", "Lab Corp"),
+        ],
+    )
+    def test_update_client_partial_update_applies_field(
+        self, commercial_user, make_client, field, value
+    ):
+        """Each updatable field is applied when provided."""
+        test_client = make_client(id=1, commercial_id=commercial_user.id)
+        session = MagicMock()
+        session.query.return_value.filter_by.return_value.first.return_value = None
+
+        update_client(
+            session=session,
+            current_user=commercial_user,
+            client=test_client,
+            **{field: value},
+        )
+
+        assert getattr(test_client, field) == value
+
+    # ---------------------------
+    # update_client — sad path
+    # ---------------------------
+
+    def test_update_client_non_owner_raises(self, commercial_user, make_client):
+        """Commercial updating another's client raises PermissionDeniedError."""
+        test_client = make_client(
+            id=1,
+            commercial_id=999,  # owned by a different commercial
+        )
+        session = MagicMock()
+
+        with pytest.raises(PermissionDeniedError):
+            update_client(
+                session=session,
+                current_user=commercial_user,
+                client=test_client,
+                first_name="Hacked",
+            )
+
+    def test_update_client_duplicate_email_raises(self, commercial_user, make_client):
+        """Updating to an existing email raises DuplicateEmailError."""
+        test_client = make_client(
+            id=1,
+            commercial_id=commercial_user.id,
+        )
+        existing = make_client(
+            id=2,
+            email="already.taken@example.com",
+            commercial_id=commercial_user.id,
+        )
+        session = MagicMock()
+        session.query.return_value.filter_by.return_value.first.return_value = existing
+
+        with pytest.raises(DuplicateEmailError):
+            update_client(
+                session=session,
+                current_user=commercial_user,
+                client=test_client,
+                email="already.taken@example.com",
+            )
+
+    def test_update_client_invalid_email_raises(self, commercial_user, make_client):
+        """Invalid email format raises ValidationError on update."""
+        test_client = make_client(
+            id=1,
+            commercial_id=commercial_user.id,
+        )
+        session = MagicMock()
+
+        with pytest.raises(ValidationError):
+            update_client(
+                session=session,
+                current_user=commercial_user,
+                client=test_client,
+                email="notanemail",
+            )
+
+    def test_update_client_non_commercial_caller_raises(
+        self, management_user, make_client
+    ):
+        """Non-Commercial caller raises PermissionDeniedError."""
+        test_client = make_client(id=1, commercial_id=1)
+        session = MagicMock()
+
+        with pytest.raises(PermissionDeniedError):
+            update_client(
+                session=session,
+                current_user=management_user,
+                client=test_client,
+                first_name="Hacked",
+            )


### PR DESCRIPTION
## Summary

Implements `update_client()` in `services/client_service.py`,
completing US-07.

Closes #37 (US-07 — Update own client)

---

## What was delivered

- `update_client()` — ownership check via `client.commercial_id ==
  current_user.id`, partial updates for all fields, email format
  validation, email uniqueness enforced, `updated_at` auto-set
  by SQLAlchemy `onupdate`
- `@require_role("COMMERCIAL")` enforced — Management and Support
  cannot update clients
- Ownership check raises `PermissionDeniedError` if commercial
  attempts to update another commercial's client

---

## Tests

- Owner updates own client → changes persisted, commit called
- Partial updates — last_name, phone, company_name each applied correctly
- Non-owner commercial → PermissionDeniedError
- Duplicate email on update → DuplicateEmailError
- Invalid email on update → ValidationError
- Non-Commercial caller → PermissionDeniedError