### PR TITLE
feat(client): implement get_clients_for_user with role-scoped queries — closes #28

### DIFF
--- a/services/client_service.py
+++ b/services/client_service.py
@@ -12,6 +12,7 @@ to them.
 
 from __future__ import annotations
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from exceptions import (
@@ -20,6 +21,8 @@ from exceptions import (
 )
 from models.client import Client
 from models.collaborator import Collaborator
+from models.contract import Contract
+from models.event import Event
 from permissions.decorators import require_role
 from utils.validation import validate_email
 
@@ -134,3 +137,30 @@ def update_client(
 
     session.commit()
     return client
+
+
+@require_role("MANAGEMENT", "COMMERCIAL", "SUPPORT")
+def get_clients_for_user(
+    session: Session,
+    current_user: Collaborator,
+) -> list[Client]:
+    """Return clients scoped to the current user's role."""
+    if current_user.role.name == "MANAGEMENT":
+        return list(session.scalars(select(Client)).all())
+
+    if current_user.role.name == "COMMERCIAL":
+        return list(
+            session.scalars(
+                select(Client).where(Client.commercial_id == current_user.id)
+            ).all()
+        )
+
+    # SUPPORT
+    return list(
+        session.scalars(
+            select(Client)
+            .join(Client.contracts)
+            .join(Event, Event.contract_id == Contract.id)
+            .where(Event.support_id == current_user.id)
+        ).all()
+    )

--- a/tests/unit/services/test_client_service.py
+++ b/tests/unit/services/test_client_service.py
@@ -14,10 +14,7 @@ from exceptions import (
     PermissionDeniedError,
     ValidationError,
 )
-from services.client_service import (
-    create_client,
-    update_client,
-)
+from services.client_service import create_client, get_clients_for_user, update_client
 
 
 class TestWriteClientService:
@@ -226,3 +223,55 @@ class TestWriteClientService:
                 client=test_client,
                 first_name="Hacked",
             )
+
+
+class TestReadClientService:
+    """Tests for client read operations — scoped by role."""
+
+    # ---------------------------
+    # Read clients - happy path
+    # ---------------------------
+
+    def test_management_sees_all_clients(self, management_user):
+        """Management user gets all clients."""
+        session = MagicMock()
+        session.scalars.return_value.all.return_value = [MagicMock(), MagicMock()]
+
+        result = get_clients_for_user(
+            session=session,
+            current_user=management_user,
+        )
+
+        assert len(result) == 2
+        session.scalars.assert_called_once()
+
+    def test_commercial_sees_only_own_clients(self, commercial_user, make_client):
+        """Commercial user gets only their own clients."""
+        own_client = make_client(id=1, commercial_id=commercial_user.id)
+
+        session = MagicMock()
+        session.scalars.return_value.all.return_value = [own_client]
+
+        result = get_clients_for_user(
+            session=session,
+            current_user=commercial_user,
+        )
+
+        assert len(result) == 1
+        assert result[0].commercial_id == commercial_user.id
+
+    def test_support_sees_only_clients_linked_to_assigned_events(
+        self, support_user, make_client
+    ):
+        """Support user gets only clients linked to their assigned events."""
+        linked_client = make_client(id=1)
+
+        session = MagicMock()
+        session.scalars.return_value.all.return_value = [linked_client]
+
+        result = get_clients_for_user(
+            session=session,
+            current_user=support_user,
+        )
+
+        assert len(result) == 1


### PR DESCRIPTION
## Summary

Implements `get_clients_for_user()` in `services/client_service.py`,
completing US-13.

Closes #28 (US-13 — View client list scoped to user)

---

## What was delivered

- `get_clients_for_user()` — role-scoped client queries using
  SQLAlchemy 2.x `session.scalars(select(...))` API
- Management → all clients
- Commercial → only clients where `commercial_id = current_user.id`
- Support → only clients linked to events where
  `support_id = current_user.id`
- Empty result returns empty list — view layer handles display in Sprint 4

---

## Tests

- Management → all clients returned
- Commercial → only own clients returned
- Support → only clients linked to assigned events returned