### PR TITLE
feat(contract): implement all contract status transitions — closes #39 #41 #42 #43 #44

### DIFF
--- a/services/collaborator_service.py
+++ b/services/collaborator_service.py
@@ -8,12 +8,15 @@ via the @require_role decorator.
 
 from __future__ import annotations
 
+import re
+
 from sqlalchemy.orm import Session, joinedload
 
 from exceptions import (
     CollaboratorNotFoundError,
     DuplicateEmailError,
     ReassignmentRequiredError,
+    ValidationError,
 )
 from models.client import Client
 from models.collaborator import Collaborator
@@ -22,9 +25,25 @@ from models.event import Event
 from models.role import Role
 from permissions.decorators import require_role
 from services.auth_service import _delete_session_file
-from utils.validation import validate_email
 
 # ── Collaborator helpers ─────────────────────────────────────────────────────
+
+
+def _validate_email(email: str) -> None:
+    """Validate that an email address has a minimally correct format.
+
+    Checks for presence of @ and a dot in the domain portion.
+    Does not perform DNS lookup or full RFC 5322 validation.
+
+    Args:
+        email: The email string to validate.
+
+    Raises:
+        ValidationError: If the email format is invalid or empty.
+    """
+    pattern = r"^[^@\s]+@[^@\s]+\.[^@\s]+$"
+    if not email or not re.match(pattern, email.strip()):
+        raise ValidationError(f"'{email}' is not a valid email address.")
 
 
 def _generate_employee_number(session: Session) -> str:
@@ -140,7 +159,7 @@ def create_collaborator(
         DuplicateEmailError: If email already exists.
     """
     # Step 1 - validate email with regex
-    validate_email(email)
+    _validate_email(email)
 
     # Step 2 — check email uniqueness
     existing = session.query(Collaborator).filter_by(email=email).first()
@@ -207,7 +226,7 @@ def update_collaborator(
         collaborator.last_name = last_name
 
     if email is not None:
-        validate_email(email)
+        _validate_email(email)
         existing = session.query(Collaborator).filter_by(email=email).first()
         if existing and existing.id != collaborator.id:
             raise DuplicateEmailError(

--- a/services/contract_service.py
+++ b/services/contract_service.py
@@ -22,6 +22,9 @@ from models.collaborator import Collaborator
 from models.contract import Contract, ContractStatus
 from permissions.decorators import require_role
 
+# ── Contract helpers ─────────────────────────────────────────────────────────────────
+
+
 # ── Public Interface ─────────────────────────────────────────────────────────────────
 
 
@@ -169,5 +172,29 @@ def record_client_signature(
         )
 
     contract.status = ContractStatus.SIGNED
+    session.commit()
+    return contract
+
+
+@require_role("MANAGEMENT")
+def record_deposit_received(
+    session: Session,
+    current_user: Collaborator,  # noqa: ARG001
+    contract: Contract,
+) -> Contract:
+    """SIGNED contract transitions to DEPOSIT_RECEIVED and sets deposit flag."""
+
+    # Step 1 — Validate state
+    if contract.status != ContractStatus.SIGNED:
+        raise InvalidStatusTransitionError(
+            f"Cannot record deposit: contract status is "
+            f"{contract.status.value}, expected SIGNED."
+        )
+
+    # Step 2 — Apply state change
+    contract.deposit_received = True
+    contract.status = ContractStatus.DEPOSIT_RECEIVED
+
+    # Step 3 — Persist
     session.commit()
     return contract

--- a/services/contract_service.py
+++ b/services/contract_service.py
@@ -23,7 +23,6 @@ from models.collaborator import Collaborator
 from models.contract import Contract, ContractStatus
 from permissions.decorators import require_role
 
-
 # ── Public Interface ─────────────────────────────────────────────────────────────────
 
 
@@ -196,7 +195,6 @@ def record_deposit_received(
         PermissionDeniedError: If current_user is not Management.
         InvalidStatusTransitionError: If contract is not SIGNED.
     """
-
     # Step 1 — Validate state
     if contract.status != ContractStatus.SIGNED:
         raise InvalidStatusTransitionError(
@@ -257,6 +255,44 @@ def record_payment(
     # Step 4 — auto-transition to PAID_IN_FULL if balance is zero
     if new_balance == 0:
         contract.status = ContractStatus.PAID_IN_FULL
+
+    session.commit()
+    return contract
+
+
+@require_role("MANAGEMENT")
+def cancel_contract(
+    session: Session,
+    current_user: Collaborator,  # noqa: ARG001 — consumed by @require_role
+    contract: Contract,
+) -> Contract:
+    """Cancel a contract from any non-terminal state.
+
+    Args:
+        session: SQLAlchemy database session.
+        current_user: The authenticated Management collaborator.
+        contract: The Contract instance to cancel.
+
+    Returns:
+        Contract: The updated contract instance.
+
+    Raises:
+        PermissionDeniedError: If current_user is not Management.
+        InvalidStatusTransitionError: If contract is already CANCELLED
+                                      or PAID_IN_FULL.
+    """
+    # Step 1 — check contract is cancellable
+    if contract.status in (ContractStatus.CANCELLED, ContractStatus.PAID_IN_FULL):
+        raise InvalidStatusTransitionError(
+            f"Cannot cancel contract: status is already " f"{contract.status.value}."
+        )
+
+    # Step 2 — cancel linked event if one exists
+    if contract.event is not None:
+        contract.event.is_cancelled = True
+
+    # Step 3 — cancel contract
+    contract.status = ContractStatus.CANCELLED
 
     session.commit()
     return contract

--- a/services/contract_service.py
+++ b/services/contract_service.py
@@ -141,3 +141,33 @@ def submit_for_signature(
     contract.status = ContractStatus.PENDING
     session.commit()
     return contract
+
+@require_role("MANAGEMENT")
+def record_client_signature(
+    session: Session,
+    current_user: Collaborator,  # noqa: ARG001 — consumed by @require_role
+    contract: Contract,
+) -> Contract:
+    """Transition contract from PENDING to SIGNED.
+
+    Args:
+        session: SQLAlchemy database session.
+        current_user: The authenticated Management collaborator.
+        contract: The Contract instance to transition.
+
+    Returns:
+        Contract: The updated contract instance.
+
+    Raises:
+        PermissionDeniedError: If current_user is not Management.
+        InvalidStatusTransitionError: If contract is not PENDING.
+    """
+    if contract.status != ContractStatus.PENDING:
+        raise InvalidStatusTransitionError(
+            f"Cannot record signature: contract status is "
+            f"{contract.status.value}, expected PENDING."
+        )
+
+    contract.status = ContractStatus.SIGNED
+    session.commit()
+    return contract

--- a/services/contract_service.py
+++ b/services/contract_service.py
@@ -16,13 +16,12 @@ from exceptions import (
     ClientNotFoundError,
     ContractNotEditableError,
     InvalidStatusTransitionError,
+    PaymentExceedsBalanceError,
 )
 from models.client import Client
 from models.collaborator import Collaborator
 from models.contract import Contract, ContractStatus
 from permissions.decorators import require_role
-
-# ── Contract helpers ─────────────────────────────────────────────────────────────────
 
 
 # ── Public Interface ─────────────────────────────────────────────────────────────────
@@ -145,6 +144,7 @@ def submit_for_signature(
     session.commit()
     return contract
 
+
 @require_role("MANAGEMENT")
 def record_client_signature(
     session: Session,
@@ -182,7 +182,20 @@ def record_deposit_received(
     current_user: Collaborator,  # noqa: ARG001
     contract: Contract,
 ) -> Contract:
-    """SIGNED contract transitions to DEPOSIT_RECEIVED and sets deposit flag."""
+    """Transition contract from SIGNED to DEPOSIT_RECEIVED.
+
+    Args:
+        session: SQLAlchemy database session.
+        current_user: The authenticated Management collaborator.
+        contract: The Contract instance to transition.
+
+    Returns:
+        Contract: The updated contract instance.
+
+    Raises:
+        PermissionDeniedError: If current_user is not Management.
+        InvalidStatusTransitionError: If contract is not SIGNED.
+    """
 
     # Step 1 — Validate state
     if contract.status != ContractStatus.SIGNED:
@@ -196,5 +209,54 @@ def record_deposit_received(
     contract.status = ContractStatus.DEPOSIT_RECEIVED
 
     # Step 3 — Persist
+    session.commit()
+    return contract
+
+
+@require_role("MANAGEMENT")
+def record_payment(
+    session: Session,
+    current_user: Collaborator,  # noqa: ARG001 — consumed by @require_role
+    contract: Contract,
+    amount_paid: Decimal,
+) -> Contract:
+    """Record a payment against a contract and reduce the remaining balance.
+
+    Args:
+        session: SQLAlchemy database session.
+        current_user: The authenticated Management collaborator.
+        contract: The Contract instance to record payment against.
+        amount_paid: The payment amount to deduct from remaining_amount.
+
+    Returns:
+        Contract: The updated contract instance.
+
+    Raises:
+        PermissionDeniedError: If current_user is not Management.
+        InvalidStatusTransitionError: If contract is not DEPOSIT_RECEIVED.
+        PaymentExceedsBalanceError: If payment would reduce balance below zero.
+    """
+    # Step 1 — validate status
+    if contract.status != ContractStatus.DEPOSIT_RECEIVED:
+        raise InvalidStatusTransitionError(
+            f"Cannot record payment: contract status is "
+            f"{contract.status.value}, expected DEPOSIT_RECEIVED."
+        )
+
+    # Step 2 — validate payment amount
+    new_balance = contract.remaining_amount - amount_paid
+    if new_balance < 0:
+        raise PaymentExceedsBalanceError(
+            f"Payment of {amount_paid} exceeds remaining balance "
+            f"of {contract.remaining_amount}."
+        )
+
+    # Step 3 — apply payment
+    contract.remaining_amount = new_balance
+
+    # Step 4 — auto-transition to PAID_IN_FULL if balance is zero
+    if new_balance == 0:
+        contract.status = ContractStatus.PAID_IN_FULL
+
     session.commit()
     return contract

--- a/services/contract_service.py
+++ b/services/contract_service.py
@@ -12,7 +12,11 @@ from decimal import Decimal
 
 from sqlalchemy.orm import Session
 
-from exceptions import ClientNotFoundError, ContractNotEditableError
+from exceptions import (
+    ClientNotFoundError,
+    ContractNotEditableError,
+    InvalidStatusTransitionError,
+)
 from models.client import Client
 from models.collaborator import Collaborator
 from models.contract import Contract, ContractStatus
@@ -104,5 +108,36 @@ def edit_contract(
     if commercial_id is not None:
         contract.commercial_id = commercial_id
 
+    session.commit()
+    return contract
+
+
+@require_role("MANAGEMENT")
+def submit_for_signature(
+    session: Session,
+    current_user: Collaborator,  # noqa: ARG001 — consumed by @require_role
+    contract: Contract,
+) -> Contract:
+    """Transition contract from DRAFT to PENDING.
+
+    Args:
+        session: SQLAlchemy database session.
+        current_user: The authenticated Management collaborator.
+        contract: The Contract instance to transition.
+
+    Returns:
+        Contract: The updated contract instance.
+
+    Raises:
+        PermissionDeniedError: If current_user is not Management.
+        InvalidStatusTransitionError: If contract is not in DRAFT status.
+    """
+    if contract.status != ContractStatus.DRAFT:
+        raise InvalidStatusTransitionError(
+            f"Cannot submit for signature: contract status is "
+            f"{contract.status.value}, expected DRAFT."
+        )
+
+    contract.status = ContractStatus.PENDING
     session.commit()
     return contract

--- a/tests/unit/services/test_contract_service.py
+++ b/tests/unit/services/test_contract_service.py
@@ -14,15 +14,17 @@ from exceptions import (
     ClientNotFoundError,
     ContractNotEditableError,
     InvalidStatusTransitionError,
+    PaymentExceedsBalanceError,
     PermissionDeniedError,
 )
 from models.contract import ContractStatus
 from services.contract_service import (
     create_contract,
     edit_contract,
-    submit_for_signature,
     record_client_signature,
     record_deposit_received,
+    record_payment,
+    submit_for_signature,
 )
 
 
@@ -228,7 +230,7 @@ class TestContractStatusTransitions:
     # ---------------------------
 
     def test_pending_contract_transitions_to_signed(
-            self, management_user, make_contract
+        self, management_user, make_contract
     ):
         """PENDING contract transitions to SIGNED on signature."""
         contract = make_contract(id=1, status=ContractStatus.PENDING)
@@ -248,7 +250,7 @@ class TestContractStatusTransitions:
     # ---------------------------
 
     def test_non_pending_contract_raises_on_signature(
-            self, management_user, make_contract
+        self, management_user, make_contract
     ):
         """Non-PENDING contract raises InvalidStatusTransitionError."""
         contract = make_contract(id=1, status=ContractStatus.DRAFT)
@@ -262,7 +264,7 @@ class TestContractStatusTransitions:
             )
 
     def test_record_signature_non_management_raises(
-            self, commercial_user, make_contract
+        self, commercial_user, make_contract
     ):
         """Non-Management caller raises PermissionDeniedError."""
         contract = make_contract(id=1, status=ContractStatus.PENDING)
@@ -280,7 +282,7 @@ class TestContractStatusTransitions:
     # ---------------------------
 
     def test_signed_contract_transitions_to_deposit_received(
-            self, management_user, make_contract
+        self, management_user, make_contract
     ):
         """SIGNED contract transitions to DEPOSIT_RECEIVED on submit."""
         contract = make_contract(id=1, status=ContractStatus.SIGNED)
@@ -301,7 +303,7 @@ class TestContractStatusTransitions:
     # ---------------------------
 
     def test_deposit_on_non_signed_contract_raises(
-            self, management_user, make_contract
+        self, management_user, make_contract
     ):
         """Test a non-signed contract does not accept deposit."""
         contract = make_contract(status=ContractStatus.PENDING)
@@ -314,9 +316,7 @@ class TestContractStatusTransitions:
                 contract=contract,
             )
 
-    def test_deposit_non_management_user_raises(
-            self, commercial_user, make_contract
-    ):
+    def test_deposit_non_management_user_raises(self, commercial_user, make_contract):
         """Test permissions on recording a deposit received"""
         contract = make_contract(status=ContractStatus.SIGNED)
         session = MagicMock()
@@ -326,4 +326,114 @@ class TestContractStatusTransitions:
                 session=session,
                 current_user=commercial_user,
                 contract=contract,
+            )
+
+    # ---------------------------
+    # record_payment — happy path
+    # ---------------------------
+
+    def test_payment_reduces_remaining_amount(self, management_user, make_contract):
+        """Valid payment reduces remaining_amount correctly."""
+        contract = make_contract(
+            id=1,
+            status=ContractStatus.DEPOSIT_RECEIVED,
+            total_amount=Decimal("5000.00"),
+            remaining_amount=Decimal("5000.00"),
+        )
+        session = MagicMock()
+
+        result = record_payment(
+            session=session,
+            current_user=management_user,
+            contract=contract,
+            amount_paid=Decimal("2000.00"),
+        )
+
+        assert result.remaining_amount == Decimal("3000.00")
+        assert result.status == ContractStatus.DEPOSIT_RECEIVED
+        session.commit.assert_called_once()
+
+    def test_payment_clears_balance_transitions_to_paid_in_full(
+            self, management_user, make_contract
+    ):
+        """Payment clearing the balance auto-transitions to PAID_IN_FULL."""
+        contract = make_contract(
+            id=1,
+            status=ContractStatus.DEPOSIT_RECEIVED,
+            total_amount=Decimal("5000.00"),
+            remaining_amount=Decimal("2000.00"),
+        )
+        session = MagicMock()
+
+        result = record_payment(
+            session=session,
+            current_user=management_user,
+            contract=contract,
+            amount_paid=Decimal("2000.00"),
+        )
+
+        assert result.remaining_amount == Decimal("0.00")
+        assert result.status == ContractStatus.PAID_IN_FULL
+        session.commit.assert_called_once()
+
+    # ---------------------------
+    # record_payment — sad path
+    # ---------------------------
+
+    def test_payment_exceeding_balance_raises(
+            self, management_user, make_contract
+    ):
+        """Payment exceeding remaining balance raises PaymentExceedsBalanceError."""
+        contract = make_contract(
+            id=1,
+            status=ContractStatus.DEPOSIT_RECEIVED,
+            total_amount=Decimal("5000.00"),
+            remaining_amount=Decimal("1000.00"),
+        )
+        session = MagicMock()
+
+        with pytest.raises(PaymentExceedsBalanceError):
+            record_payment(
+                session=session,
+                current_user=management_user,
+                contract=contract,
+                amount_paid=Decimal("2000.00"),
+            )
+
+        session.commit.assert_not_called()
+
+    def test_payment_on_non_deposit_received_contract_raises(
+            self, management_user, make_contract
+    ):
+        """Non-DEPOSIT_RECEIVED status raises InvalidStatusTransitionError."""
+        contract = make_contract(
+            id=1,
+            status=ContractStatus.SIGNED,
+        )
+        session = MagicMock()
+
+        with pytest.raises(InvalidStatusTransitionError):
+            record_payment(
+                session=session,
+                current_user=management_user,
+                contract=contract,
+                amount_paid=Decimal("1000.00"),
+            )
+
+    def test_payment_non_management_caller_raises(
+            self, commercial_user, make_contract
+    ):
+        """Non-Management caller raises PermissionDeniedError."""
+        contract = make_contract(
+            id=1,
+            status=ContractStatus.DEPOSIT_RECEIVED,
+        )
+        session = MagicMock()
+
+        with pytest.raises(PermissionDeniedError):
+            record_payment(
+                session=session,
+                current_user=commercial_user,
+                contract=contract,
+                amount_paid=Decimal("1000.00"),
             )

--- a/tests/unit/services/test_contract_service.py
+++ b/tests/unit/services/test_contract_service.py
@@ -22,6 +22,7 @@ from services.contract_service import (
     edit_contract,
     submit_for_signature,
     record_client_signature,
+    record_deposit_received,
 )
 
 
@@ -269,6 +270,59 @@ class TestContractStatusTransitions:
 
         with pytest.raises(PermissionDeniedError):
             record_client_signature(
+                session=session,
+                current_user=commercial_user,
+                contract=contract,
+            )
+
+    # ---------------------------
+    # record_deposit_received — happy path
+    # ---------------------------
+
+    def test_signed_contract_transitions_to_deposit_received(
+            self, management_user, make_contract
+    ):
+        """SIGNED contract transitions to DEPOSIT_RECEIVED on submit."""
+        contract = make_contract(id=1, status=ContractStatus.SIGNED)
+        session = MagicMock()
+
+        result = record_deposit_received(
+            session=session,
+            current_user=management_user,
+            contract=contract,
+        )
+
+        assert result.status == ContractStatus.DEPOSIT_RECEIVED
+        assert result.deposit_received is True
+        session.commit.assert_called_once()
+
+    # ---------------------------
+    # record_deposit_received — sad path
+    # ---------------------------
+
+    def test_deposit_on_non_signed_contract_raises(
+            self, management_user, make_contract
+    ):
+        """Test a non-signed contract does not accept deposit."""
+        contract = make_contract(status=ContractStatus.PENDING)
+        session = MagicMock()
+
+        with pytest.raises(InvalidStatusTransitionError):
+            record_deposit_received(
+                session=session,
+                current_user=management_user,
+                contract=contract,
+            )
+
+    def test_deposit_non_management_user_raises(
+            self, commercial_user, make_contract
+    ):
+        """Test permissions on recording a deposit received"""
+        contract = make_contract(status=ContractStatus.SIGNED)
+        session = MagicMock()
+
+        with pytest.raises(PermissionDeniedError):
+            record_deposit_received(
                 session=session,
                 current_user=commercial_user,
                 contract=contract,

--- a/tests/unit/services/test_contract_service.py
+++ b/tests/unit/services/test_contract_service.py
@@ -13,10 +13,15 @@ import pytest
 from exceptions import (
     ClientNotFoundError,
     ContractNotEditableError,
+    InvalidStatusTransitionError,
     PermissionDeniedError,
 )
 from models.contract import ContractStatus
-from services.contract_service import create_contract, edit_contract
+from services.contract_service import (
+    create_contract,
+    edit_contract,
+    submit_for_signature,
+)
 
 
 class TestWriteContractService:
@@ -161,3 +166,57 @@ class TestWriteContractService:
         )
 
         assert getattr(contract, field) == value
+
+
+class TestContractStatusTransitions:
+    """Tests for contract status transition functions."""
+
+    # ---------------------------
+    # submit_for_signature — happy path
+    # ---------------------------
+
+    def test_draft_contract_transitions_to_pending(
+        self, management_user, make_contract
+    ):
+        """DRAFT contract transitions to PENDING on submit."""
+        contract = make_contract(id=1, status=ContractStatus.DRAFT)
+        session = MagicMock()
+
+        result = submit_for_signature(
+            session=session,
+            current_user=management_user,
+            contract=contract,
+        )
+
+        assert result.status == ContractStatus.PENDING
+        session.commit.assert_called_once()
+
+    # ---------------------------
+    # submit_for_signature — sad path
+    # ---------------------------
+
+    def test_non_draft_contract_raises_on_submit(self, management_user, make_contract):
+        """Non-DRAFT contract raises InvalidStatusTransitionError."""
+        contract = make_contract(id=1, status=ContractStatus.PENDING)
+        session = MagicMock()
+
+        with pytest.raises(InvalidStatusTransitionError):
+            submit_for_signature(
+                session=session,
+                current_user=management_user,
+                contract=contract,
+            )
+
+    def test_submit_for_signature_non_management_raises(
+        self, commercial_user, make_contract
+    ):
+        """Non-Management caller raises PermissionDeniedError."""
+        contract = make_contract(id=1, status=ContractStatus.DRAFT)
+        session = MagicMock()
+
+        with pytest.raises(PermissionDeniedError):
+            submit_for_signature(
+                session=session,
+                current_user=commercial_user,
+                contract=contract,
+            )

--- a/tests/unit/services/test_contract_service.py
+++ b/tests/unit/services/test_contract_service.py
@@ -19,6 +19,7 @@ from exceptions import (
 )
 from models.contract import ContractStatus
 from services.contract_service import (
+    cancel_contract,
     create_contract,
     edit_contract,
     record_client_signature,
@@ -317,7 +318,7 @@ class TestContractStatusTransitions:
             )
 
     def test_deposit_non_management_user_raises(self, commercial_user, make_contract):
-        """Test permissions on recording a deposit received"""
+        """Test permissions on recording a deposit received."""
         contract = make_contract(status=ContractStatus.SIGNED)
         session = MagicMock()
 
@@ -354,7 +355,7 @@ class TestContractStatusTransitions:
         session.commit.assert_called_once()
 
     def test_payment_clears_balance_transitions_to_paid_in_full(
-            self, management_user, make_contract
+        self, management_user, make_contract
     ):
         """Payment clearing the balance auto-transitions to PAID_IN_FULL."""
         contract = make_contract(
@@ -380,9 +381,7 @@ class TestContractStatusTransitions:
     # record_payment — sad path
     # ---------------------------
 
-    def test_payment_exceeding_balance_raises(
-            self, management_user, make_contract
-    ):
+    def test_payment_exceeding_balance_raises(self, management_user, make_contract):
         """Payment exceeding remaining balance raises PaymentExceedsBalanceError."""
         contract = make_contract(
             id=1,
@@ -403,7 +402,7 @@ class TestContractStatusTransitions:
         session.commit.assert_not_called()
 
     def test_payment_on_non_deposit_received_contract_raises(
-            self, management_user, make_contract
+        self, management_user, make_contract
     ):
         """Non-DEPOSIT_RECEIVED status raises InvalidStatusTransitionError."""
         contract = make_contract(
@@ -420,9 +419,7 @@ class TestContractStatusTransitions:
                 amount_paid=Decimal("1000.00"),
             )
 
-    def test_payment_non_management_caller_raises(
-            self, commercial_user, make_contract
-    ):
+    def test_payment_non_management_caller_raises(self, commercial_user, make_contract):
         """Non-Management caller raises PermissionDeniedError."""
         contract = make_contract(
             id=1,
@@ -436,4 +433,92 @@ class TestContractStatusTransitions:
                 current_user=commercial_user,
                 contract=contract,
                 amount_paid=Decimal("1000.00"),
+            )
+
+    # ---------------------------
+    # cancel_contract — happy path
+    # ---------------------------
+
+    def test_cancel_contract_with_linked_event(
+        self, management_user, make_contract, make_event
+    ):
+        """Cancelling a contract also cancels the linked event."""
+        event = make_event(id=1, is_cancelled=False)
+        contract = make_contract(
+            id=1,
+            status=ContractStatus.DEPOSIT_RECEIVED,
+        )
+        contract.event = event
+        session = MagicMock()
+
+        result = cancel_contract(
+            session=session,
+            current_user=management_user,
+            contract=contract,
+        )
+
+        assert result.status == ContractStatus.CANCELLED
+        assert event.is_cancelled is True
+        session.commit.assert_called_once()
+
+    def test_cancel_contract_without_event(self, management_user, make_contract):
+        """Cancelling a contract with no linked event cancels contract only."""
+        contract = make_contract(
+            id=1,
+            status=ContractStatus.SIGNED,
+        )
+        contract.event = None
+        session = MagicMock()
+
+        result = cancel_contract(
+            session=session,
+            current_user=management_user,
+            contract=contract,
+        )
+
+        assert result.status == ContractStatus.CANCELLED
+        session.commit.assert_called_once()
+
+    # ---------------------------
+    # cancel_contract — sad path
+    # ---------------------------
+
+    def test_cancel_already_cancelled_contract_raises(
+        self, management_user, make_contract
+    ):
+        """Already CANCELLED contract raises InvalidStatusTransitionError."""
+        contract = make_contract(id=1, status=ContractStatus.CANCELLED)
+        session = MagicMock()
+
+        with pytest.raises(InvalidStatusTransitionError):
+            cancel_contract(
+                session=session,
+                current_user=management_user,
+                contract=contract,
+            )
+
+    def test_cancel_paid_in_full_contract_raises(self, management_user, make_contract):
+        """PAID_IN_FULL contract raises InvalidStatusTransitionError."""
+        contract = make_contract(id=1, status=ContractStatus.PAID_IN_FULL)
+        session = MagicMock()
+
+        with pytest.raises(InvalidStatusTransitionError):
+            cancel_contract(
+                session=session,
+                current_user=management_user,
+                contract=contract,
+            )
+
+    def test_cancel_contract_non_management_raises(
+        self, commercial_user, make_contract
+    ):
+        """Non-Management caller raises PermissionDeniedError."""
+        contract = make_contract(id=1, status=ContractStatus.DRAFT)
+        session = MagicMock()
+
+        with pytest.raises(PermissionDeniedError):
+            cancel_contract(
+                session=session,
+                current_user=commercial_user,
+                contract=contract,
             )

--- a/tests/unit/services/test_contract_service.py
+++ b/tests/unit/services/test_contract_service.py
@@ -21,6 +21,7 @@ from services.contract_service import (
     create_contract,
     edit_contract,
     submit_for_signature,
+    record_client_signature,
 )
 
 
@@ -216,6 +217,58 @@ class TestContractStatusTransitions:
 
         with pytest.raises(PermissionDeniedError):
             submit_for_signature(
+                session=session,
+                current_user=commercial_user,
+                contract=contract,
+            )
+
+    # ---------------------------
+    # record_client_signature — happy path
+    # ---------------------------
+
+    def test_pending_contract_transitions_to_signed(
+            self, management_user, make_contract
+    ):
+        """PENDING contract transitions to SIGNED on signature."""
+        contract = make_contract(id=1, status=ContractStatus.PENDING)
+        session = MagicMock()
+
+        result = record_client_signature(
+            session=session,
+            current_user=management_user,
+            contract=contract,
+        )
+
+        assert result.status == ContractStatus.SIGNED
+        session.commit.assert_called_once()
+
+    # ---------------------------
+    # record_client_signature — sad path
+    # ---------------------------
+
+    def test_non_pending_contract_raises_on_signature(
+            self, management_user, make_contract
+    ):
+        """Non-PENDING contract raises InvalidStatusTransitionError."""
+        contract = make_contract(id=1, status=ContractStatus.DRAFT)
+        session = MagicMock()
+
+        with pytest.raises(InvalidStatusTransitionError):
+            record_client_signature(
+                session=session,
+                current_user=management_user,
+                contract=contract,
+            )
+
+    def test_record_signature_non_management_raises(
+            self, commercial_user, make_contract
+    ):
+        """Non-Management caller raises PermissionDeniedError."""
+        contract = make_contract(id=1, status=ContractStatus.PENDING)
+        session = MagicMock()
+
+        with pytest.raises(PermissionDeniedError):
+            record_client_signature(
                 session=session,
                 current_user=commercial_user,
                 contract=contract,


### PR DESCRIPTION
## Summary

Implements all contract status transition functions in
`services/contract_service.py`, completing US-15 through US-19.

Closes #39 (US-15 — Submit contract for signature DRAFT → PENDING)
Closes #41 (US-16 — Record client signature PENDING → SIGNED)
Closes #42 (US-17 — Record deposit received SIGNED → DEPOSIT_RECEIVED)
Closes #43 (US-18 — Record payment → PAID_IN_FULL)
Closes #44 (US-19 — Cancel contract)

---

## What was delivered

- `submit_for_signature()` — DRAFT → PENDING
- `record_client_signature()` — PENDING → SIGNED
- `record_deposit_received()` — SIGNED → DEPOSIT_RECEIVED,
  sets `deposit_received = True`
- `record_payment()` — reduces `remaining_amount` by `amount_paid`,
  auto-transitions to PAID_IN_FULL when balance reaches zero,
  raises `PaymentExceedsBalanceError` if payment exceeds balance
- `cancel_contract()` — cancels from any non-terminal state,
  cascades cancellation to linked event if one exists

---

## Tests

- Each transition: happy path + wrong status + non-Management caller
- `record_payment`: partial payment, full clearance → PAID_IN_FULL,
  exceeds balance, wrong status, wrong role
- `cancel_contract`: with linked event, without event,
  already CANCELLED, PAID_IN_FULL, wrong role

---

## Notes

All terminal states (CANCELLED, PAID_IN_FULL) are enforced by the
service layer — Management never manually sets these values directly.
PAID_IN_FULL is always a consequence of `record_payment()` clearing
the balance. CANCELLED is always a consequence of `cancel_contract()`.