### PR TITLE
feat(contract): implement contract read operations — closes #30 #31 #32

### DIFF
--- a/services/contract_service.py
+++ b/services/contract_service.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 from exceptions import (
     ClientNotFoundError,
     ContractNotEditableError,
+    ContractNotFoundError,
     InvalidStatusTransitionError,
     PaymentExceedsBalanceError,
 )
@@ -24,6 +25,14 @@ from models.collaborator import Collaborator
 from models.contract import Contract, ContractStatus
 from models.event import Event
 from permissions.decorators import require_role
+
+# ── Contract Helper ─────────────────────────────────────────────────────────────────
+
+
+def _contract_not_found(contract_id: int) -> ContractNotFoundError:
+    """Return a ContractNotFoundError for the given ID."""
+    return ContractNotFoundError(f"No contract found with ID {contract_id}.")
+
 
 # ── Public Interface ─────────────────────────────────────────────────────────────────
 
@@ -327,7 +336,7 @@ def get_contracts_for_user(
             ).all()
         )
 
-        # SUPPORT — contracts linked to their assigned events
+    # SUPPORT — contracts linked to their assigned events
     return list(
         session.scalars(
             select(Contract)
@@ -362,11 +371,50 @@ def filter_contracts(
 
     if client_name is not None:
         results = [
-            c for c in results
+            c
+            for c in results
             if c.client is not None
-            and client_name.lower() in (
-                c.client.first_name + " " + c.client.last_name
-            ).lower()
+            and client_name.lower()
+            in (c.client.first_name + " " + c.client.last_name).lower()
         ]
 
     return results
+
+
+@require_role("MANAGEMENT", "COMMERCIAL", "SUPPORT")
+def get_contract_by_id(
+    session: Session,
+    current_user: Collaborator,
+    contract_id: int,
+) -> Contract:
+    """Return a single contract if within user's scope.
+
+    Raises:
+        ContractNotFoundError: If contract does not exist or is not accessible.
+    """
+    # Step 1 — fetch contract
+    contract: Contract | None = session.get(Contract, contract_id)
+
+    if not contract:
+        raise _contract_not_found(contract_id)
+
+    # Step 2 — role-based access control
+
+    # MANAGEMENT → full access
+    if current_user.role.name == "MANAGEMENT":
+        return contract
+
+    # COMMERCIAL → only own contracts
+    if current_user.role.name == "COMMERCIAL":
+        if contract.commercial_id != current_user.id:
+            raise _contract_not_found(contract_id)
+        return contract
+
+    # SUPPORT → only contracts linked to their events
+    if current_user.role.name == "SUPPORT":
+        if contract.event is None or contract.event.support_id != current_user.id:
+            raise _contract_not_found(contract_id)
+        return contract
+
+    # Should never be reached — @require_role enforces valid roles
+    raise _contract_not_found(contract_id)

--- a/services/contract_service.py
+++ b/services/contract_service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from exceptions import (
@@ -21,6 +22,7 @@ from exceptions import (
 from models.client import Client
 from models.collaborator import Collaborator
 from models.contract import Contract, ContractStatus
+from models.event import Event
 from permissions.decorators import require_role
 
 # ── Public Interface ─────────────────────────────────────────────────────────────────
@@ -296,3 +298,40 @@ def cancel_contract(
 
     session.commit()
     return contract
+
+
+@require_role("MANAGEMENT", "COMMERCIAL", "SUPPORT")
+def get_contracts_for_user(
+    session: Session,
+    current_user: Collaborator,
+) -> list[Contract]:
+    """Return contracts scoped to the current user's role.
+
+    Args:
+        session: SQLAlchemy database session.
+        current_user: The authenticated collaborator.
+
+    Returns:
+        list[Contract]: Contracts visible to the current user.
+
+    Raises:
+        PermissionDeniedError: If current_user has no valid role.
+    """
+    if current_user.role.name == "MANAGEMENT":
+        return list(session.scalars(select(Contract)).all())
+
+    if current_user.role.name == "COMMERCIAL":
+        return list(
+            session.scalars(
+                select(Contract).where(Contract.commercial_id == current_user.id)
+            ).all()
+        )
+
+        # SUPPORT — contracts linked to their assigned events
+    return list(
+        session.scalars(
+            select(Contract)
+            .join(Event, Event.contract_id == Contract.id)
+            .where(Event.support_id == current_user.id)
+        ).all()
+    )

--- a/services/contract_service.py
+++ b/services/contract_service.py
@@ -335,3 +335,38 @@ def get_contracts_for_user(
             .where(Event.support_id == current_user.id)
         ).all()
     )
+
+
+def filter_contracts(
+    contracts: list[Contract],
+    status: ContractStatus | None = None,
+    client_name: str | None = None,
+) -> list[Contract]:
+    """Filter a scoped list of contracts by optional criteria.
+
+    Filters are applied on top of an already-scoped list from
+    get_contracts_for_user() — never bypasses role scoping.
+
+    Args:
+        contracts: Pre-scoped list of contracts to filter.
+        status: Optional status to filter by.
+        client_name: Optional client name substring to filter by.
+
+    Returns:
+        list[Contract]: Filtered contracts matching all provided criteria.
+    """
+    results = contracts
+
+    if status is not None:
+        results = [c for c in results if c.status == status]
+
+    if client_name is not None:
+        results = [
+            c for c in results
+            if c.client is not None
+            and client_name.lower() in (
+                c.client.first_name + " " + c.client.last_name
+            ).lower()
+        ]
+
+    return results

--- a/tests/unit/services/test_contract_service.py
+++ b/tests/unit/services/test_contract_service.py
@@ -13,6 +13,7 @@ import pytest
 from exceptions import (
     ClientNotFoundError,
     ContractNotEditableError,
+    ContractNotFoundError,
     InvalidStatusTransitionError,
     PaymentExceedsBalanceError,
     PermissionDeniedError,
@@ -22,12 +23,13 @@ from services.contract_service import (
     cancel_contract,
     create_contract,
     edit_contract,
+    filter_contracts,
+    get_contract_by_id,
+    get_contracts_for_user,
     record_client_signature,
     record_deposit_received,
     record_payment,
     submit_for_signature,
-    get_contracts_for_user,
-    filter_contracts,
 )
 
 
@@ -533,13 +535,16 @@ class TestReadContractService:
     # get_contracts_for_user — happy path
     # ---------------------------
 
-    @pytest.mark.parametrize("user_fixture,expected_count", [
-        ("management_user", 2),
-        ("commercial_user", 1),
-        ("support_user", 1),
-    ])
+    @pytest.mark.parametrize(
+        "user_fixture,expected_count",
+        [
+            ("management_user", 2),
+            ("commercial_user", 1),
+            ("support_user", 1),
+        ],
+    )
     def test_get_contracts_for_user_scoped_by_role(
-            self, request, make_contract, user_fixture, expected_count
+        self, request, make_contract, user_fixture, expected_count
     ):
         """Each role gets contracts scoped to their access level."""
         user = request.getfixturevalue(user_fixture)
@@ -554,6 +559,77 @@ class TestReadContractService:
         )
 
         assert len(result) == expected_count
+
+    # ---------------------------
+    # get_contract_by_id — role-scoped access
+    # ---------------------------
+
+    @pytest.mark.parametrize(
+        "user_fixture, contract_fixture, setup_func, should_succeed",
+        [
+            # Management access
+            ("management_user", "draft_contract", None, True),
+            ("management_user", "signed_contract", None, True),
+            # Commercial access
+            (
+                "commercial_user",
+                "draft_contract",
+                lambda c, u: setattr(c, "commercial_id", u.id),
+                True,
+            ),
+            (
+                "commercial_user",
+                "signed_contract",
+                lambda c, u: setattr(c, "commercial_id", u.id + 100),
+                False,
+            ),
+            # Support access
+            (
+                "support_user",
+                "draft_contract",
+                lambda c, u: setattr(c, "event", MagicMock(support_id=u.id)),
+                True,
+            ),
+            (
+                "support_user",
+                "signed_contract",
+                lambda c, u: setattr(c, "event", MagicMock(support_id=u.id + 1)),
+                False,
+            ),
+            # Contract does not exist
+            ("management_user", None, None, False),
+        ],
+    )
+    def test_get_contract_by_id_role_scoped(
+        self, request, user_fixture, contract_fixture, setup_func, should_succeed
+    ):
+        """Parametrized test for get_contract_by_id covering all roles."""
+        user = request.getfixturevalue(user_fixture)
+        contract = (
+            request.getfixturevalue(contract_fixture) if contract_fixture else None
+        )
+
+        # Apply setup adjustments (e.g., IDs or support assignment)
+        if contract and setup_func:
+            setup_func(contract, user)
+
+        # Mock session
+        session_mock = MagicMock()
+        if contract:
+            session_mock.get.side_effect = lambda cls, contract_id: {
+                contract.id: contract
+            }.get(contract_id)
+            contract_id = contract.id
+        else:
+            session_mock.get.return_value = None
+            contract_id = 999
+
+        if should_succeed:
+            result = get_contract_by_id(session_mock, user, contract_id)
+            assert result == contract
+        else:
+            with pytest.raises(ContractNotFoundError):
+                get_contract_by_id(session_mock, user, contract_id)
 
 
 class TestFilterContracts:

--- a/tests/unit/services/test_contract_service.py
+++ b/tests/unit/services/test_contract_service.py
@@ -26,6 +26,7 @@ from services.contract_service import (
     record_deposit_received,
     record_payment,
     submit_for_signature,
+    get_contracts_for_user
 )
 
 
@@ -522,3 +523,48 @@ class TestContractStatusTransitions:
                 current_user=commercial_user,
                 contract=contract,
             )
+
+
+class TestReadContractService:
+    """Tests for contract read operations — scoped by role."""
+
+    # ---------------------------
+    # get_contracts_for_user — happy path
+    # ---------------------------
+
+    def test_management_sees_all_contracts(self, management_user):
+        """Management user gets all contracts."""
+        session = MagicMock()
+        session.scalars.return_value.all.return_value = [
+            MagicMock(), MagicMock()
+        ]
+
+        result = get_contracts_for_user(
+            session=session,
+            current_user=management_user,
+        )
+
+        assert len(result) == 2
+        session.scalars.assert_called_once()
+
+    @pytest.mark.parametrize("user_fixture,expected_count", [
+        ("management_user", 2),
+        ("commercial_user", 1),
+        ("support_user", 1),
+    ])
+    def test_get_contracts_for_user_scoped_by_role(
+            self, request, make_contract, user_fixture, expected_count
+    ):
+        """Each role gets contracts scoped to their access level."""
+        user = request.getfixturevalue(user_fixture)
+        contracts = [make_contract(id=i) for i in range(expected_count)]
+
+        session = MagicMock()
+        session.scalars.return_value.all.return_value = contracts
+
+        result = get_contracts_for_user(
+            session=session,
+            current_user=user,
+        )
+
+        assert len(result) == expected_count

--- a/tests/unit/services/test_contract_service.py
+++ b/tests/unit/services/test_contract_service.py
@@ -26,7 +26,8 @@ from services.contract_service import (
     record_deposit_received,
     record_payment,
     submit_for_signature,
-    get_contracts_for_user
+    get_contracts_for_user,
+    filter_contracts,
 )
 
 
@@ -553,3 +554,42 @@ class TestReadContractService:
         )
 
         assert len(result) == expected_count
+
+
+class TestFilterContracts:
+    """Tests for filter_contracts() — applied on top of scoped list."""
+
+    # ---------------------------
+    # filter_contracts — happy path
+    # ---------------------------
+
+    def test_filter_by_status(self, make_contract):
+        """Filter by status returns only matching contracts."""
+        signed = make_contract(id=1, status=ContractStatus.SIGNED)
+        draft = make_contract(id=2, status=ContractStatus.DRAFT)
+
+        result = filter_contracts(
+            contracts=[signed, draft],
+            status=ContractStatus.SIGNED,
+        )
+
+        assert len(result) == 1
+        assert result[0].status == ContractStatus.SIGNED
+
+    def test_filter_by_client_name(self, make_contract, make_client):
+        """Filter by client name returns only matching contracts."""
+        client_a = make_client(id=1, first_name="Marie", last_name="Curie")
+        client_b = make_client(id=2, first_name="Jean", last_name="Dupont")
+
+        contract_a = make_contract(id=1)
+        contract_b = make_contract(id=2)
+        contract_a.client = client_a
+        contract_b.client = client_b
+
+        result = filter_contracts(
+            contracts=[contract_a, contract_b],
+            client_name="Curie",
+        )
+
+        assert len(result) == 1
+        assert result[0].client.last_name == "Curie"

--- a/tests/unit/services/test_contract_service.py
+++ b/tests/unit/services/test_contract_service.py
@@ -532,21 +532,6 @@ class TestReadContractService:
     # get_contracts_for_user — happy path
     # ---------------------------
 
-    def test_management_sees_all_contracts(self, management_user):
-        """Management user gets all contracts."""
-        session = MagicMock()
-        session.scalars.return_value.all.return_value = [
-            MagicMock(), MagicMock()
-        ]
-
-        result = get_contracts_for_user(
-            session=session,
-            current_user=management_user,
-        )
-
-        assert len(result) == 2
-        session.scalars.assert_called_once()
-
     @pytest.mark.parametrize("user_fixture,expected_count", [
         ("management_user", 2),
         ("commercial_user", 1),


### PR DESCRIPTION
## Summary

Implements all contract read operations in `services/contract_service.py`, completing US-23, US-27 and US-28.

Closes #30 (US-23 — View contract list scoped by role)
Closes #31 (US-27 — Filter contract list)
Closes #32 (US-28 — View single contract detail scoped by role)

---

## What was delivered

- `get_contracts_for_user()` — role-scoped contract queries using SQLAlchemy 2.x `session.scalars(select(...))` API: Management sees all, Commercial sees own, Support sees linked via assigned events
- `filter_contracts()` — filters applied on top of scoped list, never bypasses scoping. Supports `status` and `client_name` filters
- `get_contract_by_id()` — role-scoped single contract retrieval, raises `ContractNotFoundError` if outside scope or non-existent
- `_contract_not_found()` — private helper to avoid repeated error message strings across three access control branches

---

## Tests

- `get_contracts_for_user`: parametrized across all three roles
- `filter_contracts`: filter by status, filter by client_name
- `get_contract_by_id`: fully parametrized across all roles and edge cases including non-existent contract, Commercial out-of-scope, and Support unassigned contract