### PR TITLE
Feature/sprint3 events: implement read operations (list, filter, detail) for events - closes #33, #34, #35

### DIFF
--- a/services/event_service.py
+++ b/services/event_service.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 
 from exceptions import (
     ContractNotEligibleError,
+    EventNotFoundError,
     InvalidAssignmentError,
     PermissionDeniedError,
     SchedulingConflictWarning,
@@ -23,6 +24,14 @@ from models.contract import Contract, ContractStatus
 from models.event import Event
 from permissions.decorators import require_role
 from utils.validation import validate_event_dates, validate_location
+
+# ── Event  Helper ─────────────────────────────────────────────────────────────────
+
+
+def _event_not_found(event_id: int) -> EventNotFoundError:
+    """Return an EventNotFoundError for the given ID."""
+    return EventNotFoundError(f"No event found with ID {event_id}.")
+
 
 # ── Public Interface ─────────────────────────────────────────────────────────────────
 
@@ -288,3 +297,42 @@ def filter_events(
         results = [e for e in results if e.start_date >= now]
 
     return results
+
+
+@require_role("MANAGEMENT", "COMMERCIAL", "SUPPORT")
+def get_event_by_id(
+    session: Session,
+    current_user: Collaborator,
+    event_id: int,
+) -> Event:
+    """Return a single event if within user's scope.
+
+    Raises:
+        EventNotFoundError: If event does not exist or is not accessible.
+    """
+    # Step 1 - Fetch event
+    event: Event | None = session.get(Event, event_id)
+
+    if not event:
+        raise _event_not_found(event_id)
+
+    # Step 2 - Role-based access control
+
+    # Management → full access
+    if current_user.role.name == "MANAGEMENT":
+        return event
+
+    # COMMERCIAL → only events tied to clients of theirs
+    if current_user.role.name == "COMMERCIAL":
+        if event.contract.commercial_id != current_user.id:
+            raise _event_not_found(event_id)
+        return event
+
+    # SUPPORT → only events assigned to them
+    if current_user.role.name == "SUPPORT":
+        if event.support_id != current_user.id:
+            raise _event_not_found(event_id)
+        return event
+
+    # Shouldn't need to be reached
+    raise _event_not_found(event_id)

--- a/services/event_service.py
+++ b/services/event_service.py
@@ -221,3 +221,40 @@ def assign_support(
     event.support_id = support.id
     session.commit()
     return event
+
+
+@require_role("MANAGEMENT", "COMMERCIAL", "SUPPORT")
+def get_events_for_user(
+    session: Session,
+    current_user: Collaborator,
+) -> list[Event]:
+    """Return events scoped to the current user's role.
+
+    Args:
+        session: SQLAlchemy database session.
+        current_user: The authenticated collaborator.
+
+    Returns:
+        list[Event]: Events visible to the current user.
+
+    Raises:
+        PermissionDeniedError: If current_user has no valid role.
+    """
+    if current_user.role.name == "MANAGEMENT":
+        return list(session.scalars(select(Event)).all())
+
+    if current_user.role.name == "COMMERCIAL":
+        return list(
+            session.scalars(
+                select(Event)
+                .join(Contract, Contract.id == Event.contract_id)
+                .where(Contract.commercial_id == current_user.id)
+            ).all()
+        )
+
+    # SUPPORT
+    return list(
+        session.scalars(
+            select(Event).where(Event.support_id == current_user.id)
+        ).all()
+    )

--- a/services/event_service.py
+++ b/services/event_service.py
@@ -7,7 +7,7 @@ update, and retrieval.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -254,7 +254,37 @@ def get_events_for_user(
 
     # SUPPORT
     return list(
-        session.scalars(
-            select(Event).where(Event.support_id == current_user.id)
-        ).all()
+        session.scalars(select(Event).where(Event.support_id == current_user.id)).all()
     )
+
+
+def filter_events(
+    events: list[Event],
+    support_unassigned: bool | None = None,
+    upcoming: bool | None = None,
+) -> list[Event]:
+    """Filter a scoped list of events by optional criteria.
+
+    Filters are applied on top of an already-scoped list from
+    get_events_for_user() — never bypasses role scoping.
+
+    Args:
+        events: Pre-scoped list of events to filter.
+        support_unassigned: If True, return only events with no
+                            support assigned.
+        upcoming: If True, return only events where start_date
+                  is today or in the future.
+
+    Returns:
+        list[Event]: Filtered events matching all provided criteria.
+    """
+    results = events
+
+    if support_unassigned:
+        results = [e for e in results if e.support_id is None]
+
+    if upcoming:
+        now = datetime.now(timezone.utc)
+        results = [e for e in results if e.start_date >= now]
+
+    return results

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -504,3 +504,18 @@ def mock_session_empty():
     session.query.return_value.filter_by.return_value.first.return_value = None
     session.query.return_value.count.return_value = 0
     return session
+
+
+# ── Session helpers for read services ──────────────────────────────────────
+
+
+@pytest.fixture
+def session_with_event():
+    """Return a session mock that returns a given event via session.get()."""
+
+    def _factory(event):
+        session = MagicMock()
+        session.get.return_value = event
+        return session
+
+    return _factory

--- a/tests/unit/services/test_event_service.py
+++ b/tests/unit/services/test_event_service.py
@@ -19,6 +19,7 @@ from models.contract import ContractStatus
 from services.event_service import (
     assign_support,
     create_event,
+    filter_events,
     get_events_for_user,
     update_event,
 )
@@ -294,6 +295,7 @@ class TestAssignSupportService:
                 support=support_user,
             )
 
+
 class TestReadEventService:
     """Tests for event read operations — scoped by role."""
 
@@ -301,11 +303,14 @@ class TestReadEventService:
     # get_events_for_user — happy path
     # ---------------------------
 
-    @pytest.mark.parametrize("user_fixture,expected_count", [
-        ("management_user", 2),
-        ("commercial_user", 1),
-        ("support_user", 1),
-    ])
+    @pytest.mark.parametrize(
+        "user_fixture,expected_count",
+        [
+            ("management_user", 2),
+            ("commercial_user", 1),
+            ("support_user", 1),
+        ],
+    )
     def test_get_events_for_user_scoped_by_role(
         self, request, make_event, user_fixture, expected_count
     ):
@@ -322,3 +327,43 @@ class TestReadEventService:
         )
 
         assert len(result) == expected_count
+
+    # ---------------------------
+    # filter_events — happy path
+    # ---------------------------
+
+    def test_filter_by_support_unassigned(self, make_event):
+        """filter_events returns only events with no support assigned."""
+        assigned = make_event(id=1, support_id=1)
+        unassigned = make_event(id=2, support_id=None)
+
+        result = filter_events(
+            events=[assigned, unassigned],
+            support_unassigned=True,
+        )
+
+        assert len(result) == 1
+        assert result[0].support_id is None
+
+    def test_filter_by_upcoming(self, make_event):
+        """filter_events returns only future events when upcoming=True."""
+        from datetime import datetime, timedelta, timezone
+
+        past = make_event(
+            id=1,
+            start_date=datetime.now(timezone.utc) - timedelta(days=1),
+            end_date=datetime.now(timezone.utc) - timedelta(hours=1),
+        )
+        future = make_event(
+            id=2,
+            start_date=datetime.now(timezone.utc) + timedelta(days=1),
+            end_date=datetime.now(timezone.utc) + timedelta(days=2),
+        )
+
+        result = filter_events(
+            events=[past, future],
+            upcoming=True,
+        )
+
+        assert len(result) == 1
+        assert result[0].id == 2

--- a/tests/unit/services/test_event_service.py
+++ b/tests/unit/services/test_event_service.py
@@ -11,6 +11,7 @@ import pytest
 
 from exceptions import (
     ContractNotEligibleError,
+    EventNotFoundError,
     InvalidAssignmentError,
     PermissionDeniedError,
     SchedulingConflictWarning,
@@ -20,9 +21,19 @@ from services.event_service import (
     assign_support,
     create_event,
     filter_events,
+    get_event_by_id,
     get_events_for_user,
     update_event,
 )
+
+
+# ---------------------------
+# Helper function
+# ---------------------------
+def _attach_contract(event, make_contract, commercial_id: int):
+    """Attach a valid SQLAlchemy Contract instance to an event."""
+    contract = make_contract(commercial_id=commercial_id)
+    event.contract = contract
 
 
 class TestWriteEventService:
@@ -367,3 +378,80 @@ class TestReadEventService:
 
         assert len(result) == 1
         assert result[0].id == 2
+
+    # ---------------------------
+    # get_event_by_id — happy path
+    # ---------------------------
+
+    def test_management_retrieves_any_event(
+        self, management_user, make_event, session_with_event
+    ):
+        """Management can retrieve any event by ID."""
+        event = make_event(id=1)
+        session = session_with_event(event)
+
+        result = get_event_by_id(session, management_user, event.id)
+
+        assert result == event
+
+    def test_commercial_can_access_own_client_event(
+        self, commercial_user, make_event, make_contract, session_with_event
+    ):
+        """Commercial can access own client event."""
+        event = make_event(id=1)
+        _attach_contract(event, make_contract, commercial_user.id)
+
+        session = session_with_event(event)
+
+        result = get_event_by_id(session, commercial_user, event.id)
+
+        assert result == event
+
+    def test_support_can_access_assigned_event(
+        self, support_user, make_event, session_with_event
+    ):
+        """Support can access assigned event."""
+        event = make_event(id=1, support_id=support_user.id)
+        session = session_with_event(event)
+
+        result = get_event_by_id(session, support_user, event.id)
+
+        assert result == event
+
+    # ---------------------------
+    # get_event_by_id — sad path
+    # ---------------------------
+
+    @pytest.mark.parametrize(
+        "role_fixture, setup_func",
+        [
+            ("support_user", lambda e, u, _: setattr(e, "support_id", u.id + 1)),
+            ("commercial_user", lambda e, u, mc: _attach_contract(e, mc, u.id + 1)),
+        ],
+    )
+    def test_access_denied_cases(
+        self,
+        request,
+        make_event,
+        make_contract,
+        session_with_event,
+        role_fixture,
+        setup_func,
+    ):
+        """Test permission cases with an EventNotFoundError."""
+        user = request.getfixturevalue(role_fixture)
+        event = make_event(id=1)
+
+        setup_func(event, user, make_contract)
+        session = session_with_event(event)
+
+        with pytest.raises(EventNotFoundError):
+            get_event_by_id(session, user, event.id)
+
+    def test_event_not_found(self, management_user):
+        """Tests raising of EventNotFoundError."""
+        session = MagicMock()
+        session.get.return_value = None
+
+        with pytest.raises(EventNotFoundError):
+            get_event_by_id(session, management_user, 999)

--- a/tests/unit/services/test_event_service.py
+++ b/tests/unit/services/test_event_service.py
@@ -19,6 +19,7 @@ from models.contract import ContractStatus
 from services.event_service import (
     assign_support,
     create_event,
+    get_events_for_user,
     update_event,
 )
 
@@ -292,3 +293,32 @@ class TestAssignSupportService:
                 event=event,
                 support=support_user,
             )
+
+class TestReadEventService:
+    """Tests for event read operations — scoped by role."""
+
+    # ---------------------------
+    # get_events_for_user — happy path
+    # ---------------------------
+
+    @pytest.mark.parametrize("user_fixture,expected_count", [
+        ("management_user", 2),
+        ("commercial_user", 1),
+        ("support_user", 1),
+    ])
+    def test_get_events_for_user_scoped_by_role(
+        self, request, make_event, user_fixture, expected_count
+    ):
+        """Each role gets events scoped to their access level."""
+        user = request.getfixturevalue(user_fixture)
+        events = [make_event(id=i) for i in range(expected_count)]
+
+        session = MagicMock()
+        session.scalars.return_value.all.return_value = events
+
+        result = get_events_for_user(
+            session=session,
+            current_user=user,
+        )
+
+        assert len(result) == expected_count


### PR DESCRIPTION
## Summary

This PR completes all **event read operations** for EPIC 3:

- Event list scoped by role
- Event filtering
- Single event detail access

It ensures strict role-based access control across all read endpoints.

---

## Implemented Features

### #33 — Event List (Scoped)
- `get_events_for_user`
- Management: access to all events
- Commercial: only events linked to their clients
- Support: only events assigned to them

### #34 — Event Filtering
- `filter_events`
- Filters:
  - Unassigned events
  - Upcoming events
- Applied on already scoped datasets (no scope bypass)

### #35 — Event Details
- `get_event_by_id`
- Role-based access enforcement:
  - Management → full access
  - Commercial → own client events only
  - Support → assigned events only
- Raises `EventNotFoundError` if:
  - Event does not exist
  - Event is outside user scope

---

## Testing

Unit tests added for all scenarios:

- Management retrieves any event → success
- Commercial retrieves own client event → success
- Commercial retrieves another client’s event → `EventNotFoundError`
- Support retrieves assigned event → success
- Support retrieves unassigned event → `EventNotFoundError`
- Event not found → `EventNotFoundError`

Tests use factory fixtures and a mocked session layer to isolate service logic.

---

## Design Notes

- Scope enforcement is handled at the service layer
- Unauthorized access intentionally returns `EventNotFoundError` to avoid leaking resource existence
- Filtering is applied only after scoping to preserve security boundaries

---

## Status

All acceptance criteria met.

Closes:
- #33
- #34
- #35