### PR TITLE
feat(sprint4-event-cli): implement event management CLI and close remaining Sprint 4 menu tickets — closes #82 #48 #78

### DIFF
--- a/cli/commands/collaborators.py
+++ b/cli/commands/collaborators.py
@@ -30,6 +30,7 @@ from services.collaborator_service import (
     get_collaborators,
     update_collaborator,
 )
+from utils.validation import validate_password
 from views.messages import Errors, Info, Prompts, Success
 from views.screens import render_collaborator_detail
 from views.tables import (
@@ -151,7 +152,7 @@ def _collaborator_context_menu(
         )
 
         if collaborator.is_active:
-            actions = ["Update", "Deactivate", Info.BACK]
+            actions = ["Update", "Reset password", "Deactivate", Info.BACK]
         else:
             actions = [Info.BACK]
 
@@ -164,6 +165,8 @@ def _collaborator_context_menu(
 
         if choice == "Update":
             _handle_update_collaborator(session, current_user, collaborator)
+        if choice == "Reset password":
+            _handle_reset_password(session, current_user, collaborator)
         elif choice == "Deactivate":
             deactivated = _handle_deactivate_collaborator(
                 session, current_user, collaborator
@@ -307,3 +310,29 @@ def _handle_deactivate_collaborator(
         )
     except PermissionDeniedError:
         console.print(Errors.PERMISSION_DENIED)
+
+
+def _handle_reset_password(
+    session, current_user: Collaborator, collaborator: Collaborator
+) -> None:
+    """Prompt for new password and reset collaborator credentials."""
+    new_password = questionary.password("New password:").ask()
+    confirm = questionary.password("Confirm password:").ask()
+
+    if new_password != confirm:
+        console.print(Errors.PASSWORDS_DONT_MATCH)
+        return
+
+    try:
+        validate_password(new_password)
+    except ValidationError:
+        console.print(Errors.WEAK_PASSWORD)
+        return
+
+    collaborator.set_password(new_password)
+    collaborator.must_change_password = True
+    session.commit()
+    console.print(
+        f"[green]✓ Password reset for {collaborator.full_name}. "
+        f"They will be prompted to change it on next login.[/green]"
+    )

--- a/cli/commands/events.py
+++ b/cli/commands/events.py
@@ -1,0 +1,452 @@
+"""
+Event management CLI commands.
+
+Handles all event-related menu interactions scoped by role.
+No business logic lives here — handlers call service functions
+and pass results to view functions.
+"""
+
+from __future__ import annotations
+
+import questionary
+from rich.console import Console
+from sqlalchemy import select
+
+from exceptions import (
+    ContractNotEligibleError,
+    EventNotFoundError,
+    InvalidAssignmentError,
+    PermissionDeniedError,
+    SchedulingConflictWarning,
+    ValidationError,
+)
+from models.collaborator import Collaborator
+from models.contract import Contract, ContractStatus
+from models.event import Event
+from services.event_service import (
+    assign_support,
+    create_event,
+    filter_events,
+    get_event_by_id,
+    get_events_for_user,
+    update_event,
+)
+from views.messages import Errors, Info, Prompts, Success, Warnings
+from views.screens import render_event_detail
+from views.tables import render_events_table
+
+console = Console()
+
+
+# ── Main menu ─────────────────────────────────────────────────────────────────
+
+
+def events_menu(session, current_user: Collaborator) -> None:
+    """Render the events sub-menu scoped by role."""
+    role = current_user.role.name
+
+    if role == "MANAGEMENT":
+        options = [
+            "List Events",
+            "Events Needing Support",
+            "Select Event",
+            Info.BACK,
+        ]
+    elif role == "COMMERCIAL":
+        options = [
+            "List Events",
+            "Create Event",
+            "Select Event",
+            Info.BACK,
+        ]
+    else:  # SUPPORT
+        options = [
+            "List Events",
+            "Select Event",
+            Info.BACK,
+        ]
+
+    while True:
+        choice = questionary.select(
+            "Events — select an option:",
+            choices=options,
+        ).ask()
+
+        if choice is None or choice == Info.BACK:
+            return
+
+        if choice == "List Events":
+            _handle_list_events(session, current_user)
+        elif choice == "Events Needing Support":
+            _handle_events_needing_support(session, current_user)
+        elif choice == "Create Event":
+            _handle_create_event(session, current_user)
+        elif choice == "Select Event":
+            _handle_select_event(session, current_user)
+
+
+# ── Selection and context menu ────────────────────────────────────────────────
+
+
+def _select_event_from_table(
+    session,
+    current_user: Collaborator,
+    events: list[Event] | None = None,
+) -> Event | None:
+    """Show table and prompt for ID. Returns event or None."""
+    if events is None:
+        events = get_events_for_user(session=session, current_user=current_user)
+    if not events:
+        console.print(Info.NO_EVENTS)
+        return None
+
+    console.print(render_events_table(events))
+    event_id = questionary.text("Enter event ID:").ask()
+
+    if not event_id:
+        return None
+
+    try:
+        return get_event_by_id(
+            session=session,
+            current_user=current_user,
+            event_id=int(event_id),
+        )
+    except (EventNotFoundError, ValueError):
+        console.print(Errors.NOT_FOUND)
+        return None
+
+
+def _handle_select_event(session, current_user: Collaborator) -> None:
+    """Select an event and show context menu."""
+    event = _select_event_from_table(session, current_user)
+    if not event:
+        return
+    _event_context_menu(session, current_user, event)
+
+
+def _event_context_menu(session, current_user: Collaborator, event: Event) -> None:
+    """Context menu for a selected event — actions scoped by role."""
+    role = current_user.role.name
+
+    while True:
+        render_event_detail(event)
+
+        if role == "MANAGEMENT":
+            if not event.has_support:
+                actions = ["Assign Support", Info.BACK]
+            else:
+                actions = ["Reassign Support", Info.BACK]
+        elif role == "SUPPORT" and event.support_id == current_user.id:
+            actions = ["Update Event", Info.BACK]
+        else:
+            actions = [Info.BACK]
+
+        choice = questionary.select(
+            f"Event — {event.title} — select an action:",
+            choices=actions,
+        ).ask()
+
+        if choice is None or choice == Info.BACK:
+            return
+
+        if choice in ("Assign Support", "Reassign Support"):
+            _handle_assign_support(session, current_user, event)
+        elif choice == "Update Event":
+            _handle_update_event(session, current_user, event)
+
+
+# ── Handlers ──────────────────────────────────────────────────────────────────
+
+
+def _handle_list_events(session, current_user: Collaborator) -> None:
+    """List events scoped by role with optional filter."""
+    role = current_user.role.name
+
+    filter_choices = ["None", "Upcoming", "Past"]
+    if role == "MANAGEMENT":
+        filter_choices.append("Unassigned Support")
+
+    filter_by = questionary.select("Filter by:", choices=filter_choices).ask()
+
+    try:
+        events = get_events_for_user(session=session, current_user=current_user)
+
+        if filter_by == "Upcoming":
+            events = filter_events(events, upcoming=True)
+        elif filter_by == "Past":
+            events = filter_events(events, past=True)
+        elif filter_by == "Unassigned Support":
+            events = filter_events(events, support_unassigned=True)
+
+        if not events:
+            console.print(Info.NO_EVENTS)
+            return
+
+        console.print(render_events_table(events))
+
+        # Highlight past events with outstanding balance for Management
+        if role == "MANAGEMENT":
+            payment_due = [
+                e
+                for e in events
+                if e.is_past
+                and e.contract is not None
+                and e.contract.remaining_amount > 0
+            ]
+            if payment_due:
+                console.print(
+                    f"\n[yellow]⚠ {len(payment_due)} past event(s) "
+                    f"with outstanding balance — check Contracts.[/yellow]"
+                )
+
+    except PermissionDeniedError:
+        console.print(Errors.PERMISSION_DENIED)
+
+
+def _handle_events_needing_support(session, current_user: Collaborator) -> None:
+    """Show pre-filtered list of unassigned events for Management."""
+    try:
+        events = get_events_for_user(session=session, current_user=current_user)
+        unassigned = filter_events(events, support_unassigned=True)
+
+        if not unassigned:
+            console.print("[green]✓ All events have support assigned.[/green]")
+            return
+
+        console.print(
+            f"\n[yellow]⚠ {len(unassigned)} event(s) need "
+            f"support assignment:[/yellow]\n"
+        )
+        console.print(render_events_table(unassigned))
+
+        assign_now = questionary.confirm("Select an event to assign support now?").ask()
+
+        if not assign_now:
+            return
+
+        event = _select_event_from_table(session, current_user, events=unassigned)
+        if event:
+            _handle_assign_support(session, current_user, event)
+
+    except PermissionDeniedError:
+        console.print(Errors.PERMISSION_DENIED)
+
+
+def _handle_create_event(session, current_user: Collaborator) -> None:
+    """Prompt Commercial to create event from DEPOSIT_RECEIVED contract."""
+    from datetime import datetime
+
+    # Show only DEPOSIT_RECEIVED contracts for this commercial
+    contracts = (
+        session.query(Contract)
+        .filter(
+            Contract.commercial_id == current_user.id,
+            Contract.status == ContractStatus.DEPOSIT_RECEIVED,
+        )
+        .all()
+    )
+
+    if not contracts:
+        console.print(
+            "[red]✗ No eligible contracts found. A contract must "
+            "be in DEPOSIT_RECEIVED status to create an event.[/red]"
+        )
+        return
+
+    contract_choices = [
+        f"{c.id} — {c.client.full_name if c.client else '—'} "
+        f"({c.remaining_amount:.2f} € remaining)"
+        for c in contracts
+    ]
+    contract_choices.append(Info.BACK)
+
+    contract_choice = questionary.select(
+        "Select contract:", choices=contract_choices
+    ).ask()
+
+    if not contract_choice or contract_choice == Info.BACK:
+        return
+
+    contract_id = int(contract_choice.split(" — ")[0])
+    contract = next(c for c in contracts if c.id == contract_id)
+
+    title = questionary.text("Event title:").ask()
+    if not title:
+        return
+
+    start_str = questionary.text("Start date (DD/MM/YYYY HH:MM):").ask()
+    end_str = questionary.text("End date (DD/MM/YYYY HH:MM):").ask()
+
+    try:
+        start_date = datetime.strptime(start_str, "%d/%m/%Y %H:%M")
+        end_date = datetime.strptime(end_str, "%d/%m/%Y %H:%M")
+    except ValueError:
+        console.print("[red]✗ Invalid date format. Use DD/MM/YYYY HH:MM.[/red]")
+        return
+
+    location_street = questionary.text("Street address:").ask()
+    location_city = questionary.text("City:").ask()
+    location_zip = questionary.text("Zip code:").ask()
+    location_country = questionary.text("Country:", default="France").ask()
+    attendees_str = questionary.text("Expected attendees:", default="0").ask()
+    notes = questionary.text("Notes (optional):").ask()
+
+    try:
+        attendees = int(attendees_str or 0)
+    except ValueError:
+        attendees = 0
+
+    try:
+        event = create_event(
+            session=session,
+            current_user=current_user,
+            contract=contract,
+            title=title,
+            start_date=start_date,
+            end_date=end_date,
+            location_street=location_street,
+            location_city=location_city,
+            location_zip=location_zip,
+            location_country=location_country or "France",
+            attendees=attendees,
+            notes=notes or None,
+        )
+        console.print(Success.EVENT_CREATED.format(title=event.title))
+    except (ContractNotEligibleError, PermissionDeniedError, ValidationError) as e:
+        console.print(f"[red]✗ {e}[/red]")
+
+
+def _handle_assign_support(session, current_user: Collaborator, event: Event) -> None:
+    """Show support availability and assign to event."""
+    from models.role import Role
+
+    # Get all Support collaborators
+    support_members = (
+        session.query(Collaborator)
+        .join(Role)
+        .filter(
+            Role.name == "SUPPORT",
+            Collaborator.is_active.is_(True),
+        )
+        .all()
+    )
+
+    if not support_members:
+        console.print("[red]✗ No active Support members found.[/red]")
+        return
+
+    # Build availability info
+    event_date = event.start_date.date()
+    console.print(
+        f"\n[cyan]Support availability for "
+        f"{event_date.strftime('%d/%m/%Y')}:[/cyan]\n"
+    )
+
+    support_choices = []
+    for s in support_members:
+        existing = (
+            session.execute(
+                select(Event).where(
+                    Event.support_id == s.id,
+                    Event.is_cancelled.is_(False),
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        same_day = [e for e in existing if e.start_date.date() == event_date]
+        conflict_str = (
+            f"[yellow]⚠ {len(same_day)} event(s) on this date[/yellow]"
+            if same_day
+            else "[green]✓ Available[/green]"
+        )
+        console.print(
+            f"  {s.id} — {s.full_name} — "
+            f"{len(existing)} total event(s) — {conflict_str}"
+        )
+        support_choices.append(
+            f"{s.id} — {s.full_name}" + (" ⚠ CONFLICT" if same_day else "")
+        )
+
+    support_choices.append(Info.BACK)
+    console.print()
+
+    support_choice = questionary.select(
+        "Select support member:", choices=support_choices
+    ).ask()
+
+    if not support_choice or support_choice == Info.BACK:
+        return
+
+    support_id = int(support_choice.split(" — ")[0])
+    support = next(s for s in support_members if s.id == support_id)
+
+    try:
+        assign_support(
+            session=session,
+            current_user=current_user,
+            event=event,
+            support=support,
+        )
+        console.print(Success.SUPPORT_ASSIGNED)
+
+    except SchedulingConflictWarning:
+        console.print(
+            Warnings.SCHEDULING_CONFLICT.format(
+                name=support.full_name,
+                date=event_date.strftime("%d/%m/%Y"),
+            )
+        )
+        force = questionary.confirm(Prompts.FORCE_ASSIGN).ask()
+        if not force:
+            return
+        # Force assign by directly setting support_id
+        event.support_id = support.id
+        session.commit()
+        console.print(Success.SUPPORT_ASSIGNED)
+
+    except (InvalidAssignmentError, PermissionDeniedError) as e:
+        console.print(f"[red]✗ {e}[/red]")
+
+
+def _handle_update_event(session, current_user: Collaborator, event: Event) -> None:
+    """Prompt Support to update their assigned event."""
+    try:
+        title = questionary.text("Title:", default=event.title).ask()
+        location_street = questionary.text(
+            "Street:", default=event.location_street or ""
+        ).ask()
+        location_city = questionary.text(
+            "City:", default=event.location_city or ""
+        ).ask()
+        location_zip = questionary.text("Zip:", default=event.location_zip or "").ask()
+        location_country = questionary.text(
+            "Country:", default=event.location_country or "France"
+        ).ask()
+        attendees_str = questionary.text(
+            "Attendees:", default=str(event.attendees)
+        ).ask()
+        notes = questionary.text("Notes:", default=event.notes or "").ask()
+
+        try:
+            attendees = int(attendees_str or 0)
+        except ValueError:
+            attendees = event.attendees
+
+        update_event(
+            session=session,
+            current_user=current_user,
+            event=event,
+            title=title or None,
+            location_street=location_street or None,
+            location_city=location_city or None,
+            location_zip=location_zip or None,
+            location_country=location_country or None,
+            attendees=attendees,
+            notes=notes or None,
+        )
+        console.print(Success.EVENT_UPDATED.format(title=event.title))
+    except (PermissionDeniedError, ValidationError) as e:
+        console.print(f"[red]✗ {e}[/red]")

--- a/views/menus.py
+++ b/views/menus.py
@@ -14,10 +14,9 @@ from rich.console import Console
 from rich.panel import Panel
 
 from cli.commands.clients import clients_menu
-
-# from cli.commands.events import events_menu
 from cli.commands.collaborators import collaborators_menu
 from cli.commands.contracts import contracts_menu
+from cli.commands.events import events_menu
 from db.session import get_session
 from exceptions import AuthenticationError, ValidationError
 from services.auth_service import (
@@ -47,7 +46,14 @@ def run_app() -> None:
         # Step 1 — check for existing session
         try:
             current_user = get_session_user(session)
-        except AuthenticationError:
+        except AuthenticationError as e:
+            error_msg = str(e)
+            if "deactivated" in error_msg.lower():
+                console.print(f"[red]✗ {error_msg} Session cleared.[/red]")
+                logout()
+                return
+            # Expired or invalid token — clear and prompt login
+            logout()
             current_user = None
 
         # Step 2 — login if no valid session
@@ -179,7 +185,7 @@ def _show_main_menu(session, current_user) -> None:
             contracts_menu(session, current_user)
             pass
         elif choice in ("Events", "My Events"):
-            # events_menu(session, current_user)
+            events_menu(session, current_user)
             pass
         elif choice == "Collaborators":
             collaborators_menu(session, current_user)

--- a/views/tables.py
+++ b/views/tables.py
@@ -157,7 +157,7 @@ def render_events_table(events: list[Event]) -> Table:
         show_header=True,
         header_style="bold cyan",
     )
-    table.add_column("#", style="dim", width=4)
+    table.add_column("ID", style="dim", width=4)
     table.add_column("Title")
     table.add_column("Start")
     table.add_column("End")
@@ -166,7 +166,7 @@ def render_events_table(events: list[Event]) -> Table:
     table.add_column("Support", justify="center")
     table.add_column("Status", justify="center")
 
-    for i, e in enumerate(events, start=1):
+    for e in events:
         support = (
             f"[green]ID:{e.support_id}[/green]"
             if e.support_id
@@ -178,7 +178,7 @@ def render_events_table(events: list[Event]) -> Table:
             else "[yellow]⚠ Past[/yellow]" if e.is_past else "[green]Upcoming[/green]"
         )
         table.add_row(
-            str(i),
+            str(e.id),
             e.title,
             e.start_date.strftime("%d/%m/%Y %H:%M"),
             e.end_date.strftime("%d/%m/%Y %H:%M"),


### PR DESCRIPTION
## Summary

Implements full event management CLI scoped by role, completing US-37. Also closes US-14 and US-33 now that all sub-menus are wired and session routing is fully handled.

Closes #82 (US-37 — Event management CLI)
Closes #48 (US-14 — App entry point and session routing)
Closes #78 (US-33 — Role-scoped main menu)

---

## What was delivered

### Event management CLI
- `cli/commands/events.py` — list with filters, Events Needing Support shortcut for Management, create event with French date format (Commercial), assign support with availability display and conflict warning (Management), update own event (Support)
- `views/tables.py` — render_events_table() with real DB ID
- `views/menus.py` — events_menu() wired for all three roles

### Collaborator CLI
- `cli/commands/collaborators.py` — added Reset Password option to collaborator context menu (Management)

### App entry point fixes
- `views/menus.py` — run_app() now handles deactivated user (error shown, session cleared, exit) and expired token (session cleared, login prompt shown) separately

---

## Verified manually — full end-to-end flow

1. Bob (Commercial) creates event from DEPOSIT_RECEIVED contract ✅
2. Alice (Management) sees event in "Events Needing Support" ✅
3. Alice views support availability with event count and conflict indicator ✅
4. Alice assigns Clara (Support) to the event ✅
5. Clara logs in and sees event in My Events ✅
6. Clara updates event details ✅
7. Deactivated user → error shown, session cleared, exit ✅
8. Expired token → session cleared, login prompt shown ✅